### PR TITLE
Refactor: Iterable model collections (v 1.0.10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ source/images
 todo
 package-lock.json
 .env
+/dist

--- a/lib/ledger_entry.js
+++ b/lib/ledger_entry.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const _isString = require('lodash/isString')
+const _isEmpty = require('lodash/isEmpty')
+
 const Model = require('./model')
 const BOOL_FIELDS = []
 const FIELDS = {
@@ -17,8 +20,13 @@ const FIELD_KEYS = Object.keys(FIELDS)
 class LedgerEntry extends Model {
   constructor (data = {}) {
     super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
-    const spl = this.description.split('wallet')
-    this.wallet = (spl && spl.length > 1) ? spl[spl.length - 1].trim() : null
+
+    this.wallet = null
+
+    if (_isString(this.description) && !_isEmpty(this.description)) {
+      const spl = this.description.split('wallet')
+      this.wallet = (spl && spl.length > 1) ? spl[spl.length - 1].trim() : null
+    }
   }
 
   static unserialize (arr) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const { EventEmitter } = require('events')
-const { isArray } = Array
+const _isArray = require('lodash/isArray')
+const _isObject = require('lodash/isObject')
 
 class Model extends EventEmitter {
   constructor (data = {}, fields = {}, boolFields = [], fieldKeys = []) {
@@ -11,11 +12,35 @@ class Model extends EventEmitter {
     this._boolFields = boolFields
     this._fieldKeys = fieldKeys
 
-    if (Array.isArray(data)) {
-      return Object.assign(this, this.constructor.unserialize(data))
-    }
+    // Use/assign passed in data
+    if (!_isArray(data) && _isObject(data)) {
+      Object.assign(this, data)
+    } else if (_isArray(data) && data.length > 0) {
+      // Initialize iterator/setup array-like access if passed an array of model
+      // data.
+      if (_isArray(data[0]) || _isObject(data[0])) {
+        const collection = this.constructor.unserialize(data)
+        this._collection = collection
 
-    Object.assign(this, data)
+        Object.assign(this, collection) // needed for [] access
+        this.length = collection.length
+
+        this[Symbol.iterator] = function () {
+          return {
+            _i: -1,
+            next: function () {
+              this._i++
+
+              return this._i === collection.length
+                ? { done: true }
+                : { value: collection[this._i], done: false }
+            }
+          }
+        }
+      } else {
+        Object.assign(this, this.constructor.unserialize(data))
+      }
+    }
   }
 
   serialize () {
@@ -47,7 +72,7 @@ class Model extends EventEmitter {
   }
 
   static unserialize (data, fields, boolFields, fieldKeys) {
-    if (isArray(data) && isArray(data[0])) {
+    if (_isArray(data) && (_isArray(data[0]) || _isObject(data[0]))) {
       return data.map(m => {
         return Model.unserialize(m, fields, boolFields, fieldKeys)
       })
@@ -58,7 +83,7 @@ class Model extends EventEmitter {
     fieldKeys.forEach((key) => {
       if ((fields[key] + '').length === 0) return
 
-      if (isArray(data)) {
+      if (_isArray(data)) {
         obj[key] = data[fields[key]]
       } else {
         obj[key] = data[key]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=7"

--- a/test/helpers/test_model.js
+++ b/test/helpers/test_model.js
@@ -52,6 +52,55 @@ const testModel = ({ values = {}, model, orderedFields, boolFields = [] }) => {
     checkModelFields(m)
   })
 
+  it('constructs from an array of arrays', () => {
+    const m = new Model([fieldValues, fieldValues, fieldValues])
+    const mArr = [...m]
+
+    // test [] access
+    for (let i = 0; i < m.length; i += 1) {
+      checkModelFields(m[i])
+    }
+
+    // test iterator
+    for (let i = 0; i < mArr.length; i += 1) {
+      checkModelFields(mArr[i])
+    }
+
+    assert.strictEqual(m.length, mArr.length)
+
+    // test equality
+    for (let i = 0; i < m.length; i += 1) {
+      assert.deepStrictEqual(m[i], mArr[i])
+    }
+  })
+
+  it('constructs from an array of objects', () => {
+    const data = {}
+    fields.forEach(f => (f !== null) && (data[f] = f))
+    boolFields.forEach((f) => { data[f] = false })
+    Object.assign(data, values)
+
+    const m = new Model([data, data, data])
+    const mArr = [...m]
+
+    // test [] access
+    for (let i = 0; i < m.length; i += 1) {
+      checkModelFields(m[i])
+    }
+
+    // test iterator
+    for (let i = 0; i < mArr.length; i += 1) {
+      checkModelFields(mArr[i])
+    }
+
+    assert.strictEqual(m.length, mArr.length)
+
+    // test equality
+    for (let i = 0; i < m.length; i += 1) {
+      assert.deepStrictEqual(m[i], mArr[i])
+    }
+  })
+
   it('serializes correctly', () => {
     const data = {}
     fields.forEach(f => (f !== null) && (data[f] = f))


### PR DESCRIPTION
Enables this:

```js
  it('constructs from an array of arrays', () => {
    const m = new Model([fieldValues, fieldValues, fieldValues])
    const mArr = [...m]

    // test [] access
    for (let i = 0; i < m.length; i += 1) {
      checkModelFields(m[i])
    }

    // test iterator
    for (let i = 0; i < mArr.length; i += 1) {
      checkModelFields(mArr[i])
    }

    assert.strictEqual(m.length, mArr.length)

    // test equality
    for (let i = 0; i < m.length; i += 1) {
      assert.deepStrictEqual(m[i], mArr[i])
    }
  })
```