### PR TITLE
V2 rest integration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+# 1.1.0
+- adds function Position.claim
+- adds function FundingOffer.submit
+- adds function FundingOffer.close
+- adds function FundingOffer.cancel
+
 # 1.0.13
 - fix: (Model bool field handling) un-quote key in indexOf call
 - manifest: add build script

--- a/lib/funding_offer.js
+++ b/lib/funding_offer.js
@@ -26,11 +26,11 @@ const FIELD_KEYS = Object.keys(FIELDS)
 class FundingOffer extends Model {
   /**
   * @param {Object|Array} data - either a map of order fields or a raw array
-  * @param {Object} handler - optional, rest or websocket object capable of submitting funding offers
+  * @param {Object} _apiInterface - optional, rest or websocket object capable of submitting funding offers
   */
-  constructor (data = {}, handler) {
+  constructor (data = {}, apiInterface) {
     super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
-    this._handler = handler
+    this._apiInterface = apiInterface
   }
 
   static unserialize (arr) {
@@ -38,7 +38,8 @@ class FundingOffer extends Model {
   }
 
   /**
-  * Creates an order map that can be passed to the `on` command.
+  * Creates an order map that can be used in either the websocket `on`
+  * command or a rest request body
   *
   * @return {Object} o
   */
@@ -54,31 +55,39 @@ class FundingOffer extends Model {
   }
 
   /**
-   * @param {handler} handler - optional ws or rest, defaults to internal ws
+   * @param {WSv2|Rest2} apiInterface  - optional ws or rest, defaults to internal ws
    * @return {Promise} p
    */
-  submit (handler = this._handler) {
-    if (!handler) return Promise.reject(new Error('no submit handler'))
+  submit (apiInterface = this._apiInterface ) {
+    if (!apiInterface) return Promise.reject(new Error('no API interface provided'))
 
-    return handler.submitFundingOffer(this).then((offerArray) => {
+    return apiInterface.submitFundingOffer(this).then((offerArray) => {
       Object.assign(this, FundingOffer.unserialize(offerArray))
       return this
     })
   }
 
-  cancel (handler = this._handler) {
-    if (!handler) return Promise.reject(new Error('no submit handler'))
+  /**
+   * @param {WSv2|Rest2} apiInterface  - optional ws or rest, defaults to internal ws
+   * @return {Promise} p
+   */
+  cancel (apiInterface = this._apiInterface ) {
+    if (!apiInterface) return Promise.reject(new Error('no API interface provided'))
 
-    return handler.cancelFundingOffer(this.id).then((offerArray) => {
+    return apiInterface.cancelFundingOffer(this.id).then((offerArray) => {
       Object.assign(this, FundingOffer.unserialize(offerArray))
       return this
     })
   }
 
-  close (handler = this._handler) {
-    if (!handler) return Promise.reject(new Error('no submit handler'))
+  /**
+   * @param {WSv2|Rest2} apiInterface  - optional ws or rest, defaults to internal ws
+   * @return {Promise} p
+   */
+  close (apiInterface = this._apiInterface ) {
+    if (!apiInterface) return Promise.reject(new Error('no API interface provided'))
 
-    return handler.closeFunding({ id: this.id, type: this.type }).then((offerArray) => {
+    return apiInterface.closeFunding({ id: this.id, type: this.type }).then((offerArray) => {
       Object.assign(this, FundingOffer.unserialize(offerArray))
       return this
     })

--- a/lib/funding_offer.js
+++ b/lib/funding_offer.js
@@ -2,7 +2,7 @@
 
 const Model = require('./model')
 const BOOL_FIELDS = ['notify', 'hidden', 'renew']
-const { prepareAmount, preparePrice } = require('bfx-api-node-util')
+const { prepareAmount } = require('bfx-api-node-util')
 const FIELDS = {
   id: 0,
   symbol: 1,

--- a/lib/funding_offer.js
+++ b/lib/funding_offer.js
@@ -2,6 +2,7 @@
 
 const Model = require('./model')
 const BOOL_FIELDS = ['notify', 'hidden', 'renew']
+const { prepareAmount, preparePrice } = require('bfx-api-node-util')
 const FIELDS = {
   id: 0,
   symbol: 1,
@@ -23,12 +24,64 @@ const FIELDS = {
 const FIELD_KEYS = Object.keys(FIELDS)
 
 class FundingOffer extends Model {
-  constructor (data = {}) {
+  /**
+  * @param {Object|Array} data - either a map of order fields or a raw array
+  * @param {Object} handler - optional, rest or websocket object capable of submitting funding offers
+  */
+  constructor (data = {}, handler) {
     super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    this._handler = handler
   }
 
   static unserialize (arr) {
     return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  }
+
+  /**
+  * Creates an order map that can be passed to the `on` command.
+  *
+  * @return {Object} o
+  */
+  toNewOfferPacket () {
+    return {
+      type: this.type,
+      symbol: this.symbol,
+      amount: prepareAmount(+this.amount),
+      rate: prepareAmount(+this.rate),
+      period: this.period,
+      flags: this.flags
+    }
+  }
+
+  /**
+   * @param {handler} handler - optional ws or rest, defaults to internal ws
+   * @return {Promise} p
+   */
+  submit (handler = this._handler) {
+    if (!handler) return Promise.reject(new Error('no submit handler'))
+
+    return handler.submitFundingOffer(this).then((offerArray) => {
+      Object.assign(this, FundingOffer.unserialize(offerArray))
+      return this
+    })
+  }
+
+  cancel (handler = this._handler) {
+    if (!handler) return Promise.reject(new Error('no submit handler'))
+
+    return handler.cancelFundingOffer(this.id).then((offerArray) => {
+      Object.assign(this, FundingOffer.unserialize(offerArray))
+      return this
+    })
+  }
+
+  close (handler = this._handler) {
+    if (!handler) return Promise.reject(new Error('no submit handler'))
+
+    return handler.closeFunding({ id: this.id, type: this.type }).then((offerArray) => {
+      Object.assign(this, FundingOffer.unserialize(offerArray))
+      return this
+    })
   }
 }
 

--- a/lib/order.js
+++ b/lib/order.js
@@ -35,14 +35,14 @@ let lastCID = Date.now()
 
 /**
  * High level order model; provides methods for execution & can stay updated via
- * a WSv2 connection
+ * a WSv2 connection or used to execute as a rest payload
  */
 class Order extends Model {
   /**
    * @param {Object|Array} data - either a map of order fields or a raw array
-   * @param {WSv2} ws - optional, saved for a later call to registerListeners()
+   * @param {Object} apiInterface - optional, saved for a later call to registerListeners()
    */
-  constructor (data = {}, ws) {
+  constructor (data = {}, apiInterface) {
     super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
 
     if (!this.flags) this.flags = 0
@@ -51,7 +51,7 @@ class Order extends Model {
     if (typeof data.postonly !== 'undefined') this.setPostOnly(data.postonly)
     if (typeof data.reduceonly !== 'undefined') this.setReduceOnly(data.reduceonly)
 
-    this._ws = ws
+    this._apiInterface = apiInterface
 
     this._onWSOrderNew = this._onWSOrderNew.bind(this)
     this._onWSOrderUpdate = this._onWSOrderUpdate.bind(this)
@@ -170,10 +170,10 @@ class Order extends Model {
    * amount.
    *
    * @param {Object} changes
-   * @param {WSv2} ws - optional, defaults to internal instance
-   * @return {Promise} p - resolves on ws2 confirmation, or rejects if no ws2
+   * @param {WSv2|Rest2} apiInterface - optional ws or rest, defaults to internal instance
+   * @return {Promise} p - resolves on ws2 confirmation or rest response
    */
-  update (changes = {}, ws = this._ws) {
+  update (changes = {}, apiInterface = this._apiInterface) {
     const keys = Object.keys(changes)
 
     // Apply change locally
@@ -209,8 +209,8 @@ class Order extends Model {
       changes.price_trailing = preparePrice(changes.price_trailing)
     }
 
-    return ws
-      ? ws.updateOrder(changes)
+    return apiInterface
+      ? apiInterface.updateOrder(changes)
       : Promise.reject(new Error('no ws client available'))
   }
 
@@ -233,10 +233,10 @@ class Order extends Model {
   /**
    * Registers for updates/persistence on the specified ws2 instance
    *
-   * @param {WSv2} ws - optional, defaults to internal ws
+   * @param {Object} apiInterface - optional, defaults to internal ws
    */
-  registerListeners (ws = this._ws) {
-    if (!ws) return
+  registerListeners (apiInterface = this._apiInterface) {
+    if (!apiInterface) return
 
     const chanData = {
       symbol: this.symbol,
@@ -247,20 +247,21 @@ class Order extends Model {
     if (_isFinite(+this.gid)) chanData.gid = +this.gid
     if (_isFinite(+this.cid)) chanData.cid = +this.cid
 
-    ws.onOrderNew(chanData, this._onWSOrderNew)
-    ws.onOrderUpdate(chanData, this._onWSOrderUpdate)
-    ws.onOrderClose(chanData, this._onWSOrderClose)
+    apiInterface.onOrderNew(chanData, this._onWSOrderNew)
+    apiInterface.onOrderUpdate(chanData, this._onWSOrderUpdate)
+    apiInterface.onOrderClose(chanData, this._onWSOrderClose)
 
-    this._ws = ws
+    this._apiInterface = apiInterface
   }
 
   /**
-   * Removes update listeners from the specified ws2 instance
+   * Removes update listeners from the specified ws2 instance.
+   * Will fail if rest interface is provided.
    *
-   * @param {WSv2} ws - optional, defaults to internal ws
+   * @param {WSv2|Rest2} apiInterface - optional ws defaults to internal ws
    */
-  removeListeners (ws = this._ws) {
-    if (ws) ws.removeListeners(this.cbGID())
+  removeListeners (apiInterface = this._apiInterface) {
+    if (apiInterface) apiInterface.removeListeners(this.cbGID())
   }
 
   /**
@@ -271,43 +272,43 @@ class Order extends Model {
   }
 
   /**
-   * @param {WSv2} ws - optional, defaults to internal ws
+   * @param {WSv2|Rest2} apiInterface - optional ws or rest, defaults to internal ws
    * @return {Promise} p
    */
-  submit (ws = this._ws) {
-    if (!ws) return Promise.reject(new Error('no ws connection'))
+  submit (apiInterface = this._apiInterface) {
+    if (!apiInterface) return Promise.reject(new Error('no API interface provided'))
 
-    return ws.submitOrder(this).then((orderArr) => {
+    return apiInterface.submitOrder(this).then((orderArr) => {
       Object.assign(this, Order.unserialize(orderArr))
       return this
     })
   }
 
   /**
-   * @param {WSv2} ws - optional, defaults to internal ws
+   * @param {WSv2|Rest2} apiInterface - optional ws or rest, defaults to internal ws
    * @return {Promise} p
    */
-  cancel (ws = this._ws) {
-    if (!ws) return Promise.reject(new Error('no ws connection'))
+  cancel (apiInterface = this._apiInterface) {
+    if (!apiInterface) return Promise.reject(new Error('no API interface provided'))
     if (!this.id) return Promise.reject(new Error('order has no ID'))
 
-    return ws.cancelOrder(this.id)
+    return apiInterface.cancelOrder(this.id)
   }
 
   /**
    * Equivalent to calling cancel() followed by submit()
    *
-   * @param {WSv2} ws - optional, defaults to internal ws
+   * @param {WSv2|Rest2} apiInterface - optional ws or rest, defaults to internal ws
    * @return {Promise} p
    */
-  recreate (ws = this._ws) {
-    if (!ws) return Promise.reject(new Error('no ws connection'))
+  recreate (apiInterface = this._apiInterface) {
+    if (!apiInterface) return Promise.reject(new Error('no API interface provided'))
     if (!this.id) return Promise.reject(new Error('order has no ID'))
 
-    return this.cancel(ws).then(() => {
+    return this.cancel(apiInterface).then(() => {
       this.id = null
 
-      return this.submit(ws)
+      return this.submit(apiInterface)
     })
   }
 

--- a/lib/position.js
+++ b/lib/position.js
@@ -26,12 +26,31 @@ const FIELDS = {
 const FIELD_KEYS = Object.keys(FIELDS)
 
 class Position extends Model {
-  constructor (data = {}) {
+  /**
+  * @param {Object|Array} data - either a map of order fields or a raw array
+  * @param {Object} handler - optional, rest or websocket object thats capable of submitting position changes
+  */
+  constructor (data = {}, handler) {
     super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    this._handler = handler
   }
 
   static unserialize (arr) {
     return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  }
+
+  /**
+   * @param {handler} handler - optional ws or rest, defaults to internal ws
+   * @return {Promise} p
+   */
+  claim (handler = this._handler) {
+    if (!handler) return Promise.reject(new Error('no claim handler'))
+
+    handler.claimPosition(this.id)
+      .then((positionArray) => {
+        Object.assign(this, Position.unserialize(positionArray))
+        return this
+      })
   }
 }
 

--- a/lib/position.js
+++ b/lib/position.js
@@ -27,12 +27,12 @@ const FIELD_KEYS = Object.keys(FIELDS)
 
 class Position extends Model {
   /**
-  * @param {Object|Array} data - either a map of order fields or a raw array
-  * @param {Object} handler - optional, rest or websocket object thats capable of submitting position changes
+  * @param {Object} data - either a map of order fields or a raw array
+  * @param {WSv2|Rest2} apiInterface - optional, rest or websocket object thats capable of submitting position changes
   */
-  constructor (data = {}, handler) {
+  constructor (data = {}, apiInterface) {
     super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
-    this._handler = handler
+    this._apiInterface = apiInterface
   }
 
   static unserialize (arr) {
@@ -40,13 +40,13 @@ class Position extends Model {
   }
 
   /**
-   * @param {handler} handler - optional ws or rest, defaults to internal ws
+   * @param {WSv2|Rest2} apiInterface - optional ws or rest, defaults to internal ws
    * @return {Promise} p
    */
-  claim (handler = this._handler) {
-    if (!handler) return Promise.reject(new Error('no claim handler'))
+  claim (apiInterface = this._apiInterface) {
+    if (!apiInterface) return Promise.reject(new Error('no claim handler'))
 
-    handler.claimPosition(this.id)
+    apiInterface.claimPosition(this.id)
       .then((positionArray) => {
         Object.assign(this, Position.unserialize(positionArray))
         return this

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=7"

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
   "homepage": "http://bitfinexcom.github.io/bfx-api-node-models/",
   "devDependencies": {
     "babel-eslint": "^10.0.3",
-    "bfx-api-node-rest": "^1.1.3",
+    "bfx-api-node-rest": "git+http://github.com/bitfinexcom/bfx-api-node-rest.git#semver:^1.1.3",
     "chai": "^4.2.0",
     "mocha": "^6.2.0",
     "standard": "^14.1.0"
   },
   "dependencies": {
-    "bfx-api-node-util": "^1.0.2",
+    "bfx-api-node-util": "git+http://github.com/bitfinexcom/bfx-api-node-util.git#semver:^1.0.2",
     "bluebird": "^3.5.5",
     "crc-32": "^1.2.0",
     "debug": "^4.1.1"


### PR DESCRIPTION
### Description:
With the new addition of the v2 endpoints to handle orders/positions and funding offers, I thought it would be good to follow the same (ws) object orientated approach and pass the rest instance as a handler. For example:

```
 const o = new Order({
  cid: Date.now(),
  symbol: 'tBTCUSD',
  price: 18000,
  amount: -0.02,
  type: Order.type.LIMIT,
  lev: 10
}, rest) // <-- could pass is ws or rest instance

o.submit()
```

see the parent PR https://github.com/bitfinexcom/bitfinex-api-node/pull/502 for more info

### Breaking changes:
None

### New features:
- [x] Position.claim
- [x] FundingOffer.submit
- [x] FundingOffer.close
- [x] FundingOffer.cancel

### Fixes:
None

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
