### PR TITLE
Add extra order fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.1.2
+- models/order: add fields hidden, routing and meta
+
 # 1.1.1
 - docs: create/update
 

--- a/lib/order.js
+++ b/lib/order.js
@@ -19,14 +19,28 @@ const FIELDS = {
   type: 8,
   typePrev: 9,
   mtsTIF: 10,
+  // placeholder
+  // placeholder
   flags: 12,
   status: 13,
+  // placeholder
+  // placeholder
   price: 16,
   priceAvg: 17,
   priceTrailing: 18,
   priceAuxLimit: 19,
+  // placeholder
+  // placeholder
+  // placeholder
   notify: 23,
-  placedId: 25
+  hidden: 24,
+  placedId: 25,
+  // placeholder
+  // placeholder
+  routing: 28,
+  // placeholder
+  // placeholder
+  meta: 31
 }
 
 const FIELD_KEYS = Object.keys(FIELDS)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=7"

--- a/test/lib/models/order.js
+++ b/test/lib/models/order.js
@@ -8,12 +8,12 @@ const testModel = require('../../helpers/test_model')
 describe('Order model', () => {
   testModel({
     model: Order,
-    boolFields: ['notify'],
+    boolFields: ['notify', 'hidden'],
     orderedFields: [
       'id', 'gid', 'cid', 'symbol', 'mtsCreate', 'mtsUpdate', 'amount',
       'amountOrig', 'type', 'typePrev', 'mtsTIF', null, 'flags', 'status', null,
       null, 'price', 'priceAvg', 'priceTrailing', 'priceAuxLimit', null, null,
-      null, 'notify', null, 'placedId'
+      null, 'notify', 'hidden', 'placedId', null, null, 'routing', null, null, 'meta'
     ]
   })
 


### PR DESCRIPTION
### Description:
This PR adds a few missing fields to the order model.

### Breaking changes:
None

### New features:
- [x] models/order: add fields - hidden, routing and meta

### Fixes:
None

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Tests added or updated
- ~~Documentation updated~~
