### PR TITLE
Fix: OCO field pop on on packets, bump 1.1.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.1.3
+- models/Order: fix OCO field population on on packets
+
 # 1.1.2
 - models/order: add fields hidden, routing and meta
 

--- a/lib/order.js
+++ b/lib/order.js
@@ -79,10 +79,12 @@ class Order extends Model {
     super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
 
     if (!this.flags) this.flags = 0
-    if (typeof data.oco !== 'undefined') this.setOCO(data.oco)
     if (typeof data.hidden !== 'undefined') this.setHidden(data.hidden)
     if (typeof data.postonly !== 'undefined') this.setPostOnly(data.postonly)
     if (typeof data.reduceonly !== 'undefined') this.setReduceOnly(data.reduceonly)
+    if (typeof data.oco !== 'undefined') {
+      this.setOCO(data.oco, data.priceAuxLimit, data.cidOCO)
+    }
 
     this._apiInterface = apiInterface
 
@@ -151,8 +153,11 @@ class Order extends Model {
    * @param {boolean} v
    * @param {number?} stopPrice - optional, defaults to current value
    */
-  setOCO (v, stopPrice = this.priceAuxLimit) {
-    if (v) this.priceAuxLimit = stopPrice
+  setOCO (v, stopPrice = this.priceAuxLimit, cidOCO = this.cidOCO) {
+    if (v) {
+      this.priceAuxLimit = stopPrice
+      this.cidOCO = cidOCO
+    }
 
     this._modifyFlag(Order.flags.OCO, v)
   }
@@ -481,6 +486,7 @@ class Order extends Model {
     if (this.priceAuxLimit !== null && !Number.isNaN(+this.priceAuxLimit)) {
       if (this.flags & Order.flags.OCO) {
         data.price_oco_stop = preparePrice(+this.priceAuxLimit)
+        data.cid_oco = this.cidOCO
       } else {
         data.price_aux_limit = preparePrice(+this.priceAuxLimit)
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
Adds missing `oco_id` field to new order packets w/ `OCO` flag.

### Fixes:
- [x] OCO order `on` packet format

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
