### PR TITLE
Add book item

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,10 @@
 # 1.1.5
+
+- fix: generate orderbook checksum using strings to prevent
+  https://github.com/bitfinexcom/bitfinex-api-node/issues/511
+
+# 1.1.5
+
 - feature: support affiliateCode field in Order class
 
 # 1.1.4

--- a/lib/order_book.js
+++ b/lib/order_book.js
@@ -91,29 +91,29 @@ class OrderBook extends EventEmitter {
       const ask = this.asks[i]
 
       if (bid) {
-        const price = raw ? bid[0] : Number(preparePrice(bid[0]))
+        let price = bid[0]
+        const amount = bid.length === 4 ? bid[3] : bid[2]
+        if (!raw && typeof price !== 'string') {
+          price =  Number(preparePrice(price))
+          price = /e/.test(price + '')
+            ? price.toFixed(Math.abs((price + '').split('e')[1]) + 1) // i.e. 1.7e-7 to fixed
+            : price
+        }
 
-        data.push(
-          raw
-            ? price
-            : /e/.test(price + '')
-              ? price.toFixed(Math.abs((price + '').split('e')[1]) + 1) // i.e. 1.7e-7 to fixed
-              : price,
-          bid.length === 4 ? bid[3] : bid[2] // amount
-        )
+        data.push(price, amount)
       }
 
       if (ask) {
-        const price = raw ? ask[0] : Number(preparePrice(ask[0]))
+        let price = ask[0]
+        const amount = ask.length === 4 ? ask[3] : ask[2]
+        if (!raw && typeof price !== 'string') {
+          price =  Number(preparePrice(price))
+          price = /e/.test(price + '')
+            ? price.toFixed(Math.abs((price + '').split('e')[1]) + 1) // i.e. 1.7e-7 to fixed
+            : price
+        }
 
-        data.push(
-          raw
-            ? price
-            : /e/.test(price + '')
-              ? price.toFixed(Math.abs((price + '').split('e')[1]) + 1) // i.e. 1.7e-7 to fixed
-              : price,
-          ask.length === 4 ? ask[3] : ask[2] //
-        )
+        data.push(price, amount)
       }
     }
 
@@ -132,7 +132,7 @@ class OrderBook extends EventEmitter {
 
     // find first ask (book is sorted bids first)
     for (let i = 0; i < arr.length; i += 1) {
-      if ((arr[i].length === 4 ? -arr[i][3] : arr[i][2]) < 0) {
+      if ((arr[i].length === 4 ? Number(-arr[i][3]) : Number(arr[i][2])) < 0) {
         topAskI = i
         break
       }
@@ -154,41 +154,33 @@ class OrderBook extends EventEmitter {
         : arr[topAskI + i]
 
       if (bid) {
-        const price = raw ? bid[0] : Number(preparePrice(bid[0]))
-
-        data.push(
-          raw
-            ? bid[0]
-            : /e/.test(price + '')
-              ? price.toFixed(Math.abs((price + '').split('e')[1]) + 1) // i.e. 1.7e-7 to fixed
-              : price, // order ID or price
-          bid.length === 4 ? bid[3] : bid[2] // amount
-        )
+        let price = bid[0]
+        const amount = bid.length === 4 ? bid[3] : bid[2]
+        if (!raw && typeof price !== 'string') {
+          price =  Number(preparePrice(price))
+          price = /e/.test(price + '')
+            ? price.toFixed(Math.abs((price + '').split('e')[1]) + 1) // i.e. 1.7e-7 to fixed
+            : price
+        }
+        data.push(price, amount)
       }
 
       if (ask) {
-        const price = raw ? ask[0] : Number(preparePrice(ask[0]))
-
-        data.push(
-          raw
-            ? ask[0]
-            : /e/.test(price + '')
-              ? price.toFixed(Math.abs((price + '').split('e')[1]) + 1) // i.e. 1.7e-7 to fixed
-              : price,
-          ask.length === 4 ? ask[3] : ask[2]
-        )
+        let price = ask[0]
+        const amount = ask.length === 4 ? ask[3] : ask[2]
+        if (!raw && typeof price !== 'string') {
+          price =  Number(preparePrice(price))
+          price = /e/.test(price + '')
+            ? price.toFixed(Math.abs((price + '').split('e')[1]) + 1) // i.e. 1.7e-7 to fixed
+            : price
+        }
+        data.push(price, amount)
       }
     }
 
     return CRC.str(data.join(':'))
   }
 
-  /**
-   * Resets the internal bid/ask arrays and re-populates them with the provided
-   * snapshot.
-   *
-   * @param {Array[]} snapshot
-   */
   updateFromSnapshot (snapshot) {
     this.bids = []
     this.asks = []
@@ -199,13 +191,13 @@ class OrderBook extends EventEmitter {
 
     for (let i = 0; i < snapshot.length; i++) {
       if (snapshot[i].length === 4) {
-        if (snapshot[i][3] < 0) {
+        if (Number(snapshot[i][3]) < 0) {
           this.bids.push(snapshot[i])
         } else {
           this.asks.push(snapshot[i])
         }
       } else {
-        if (snapshot[i][2] < 0) {
+        if (Number(snapshot[i][2]) < 0) {
           this.asks.push(snapshot[i])
         } else {
           this.bids.push(snapshot[i])
@@ -226,14 +218,15 @@ class OrderBook extends EventEmitter {
     const priceI = raw
       ? entry.length === 4 ? 2 : 1
       : 0
-    const count = raw ? -1 : entry.length === 4 ? entry[2] : entry[1]
-    const price = entry[priceI]
-    const oID = entry[0] // only for raw books
-    const amount = entry.length === 4 ? entry[3] : entry[2]
-    const dir = entry.length === 4
+    const numEntry = entry.map((x) => Number(x))
+    const count = raw ? -1 : numEntry.length === 4 ? numEntry[2] : numEntry[1]
+    const price = numEntry[priceI]
+    const oID = numEntry[0] // only for raw books
+    const amount = numEntry.length === 4 ? numEntry[3] : numEntry[2]
+    const dir = numEntry.length === 4
       ? amount < 0 ? 1 : -1
       : amount < 0 ? -1 : 1
-    const side = entry.length === 4
+    const side = numEntry.length === 4
       ? amount < 0 ? this.bids : this.asks
       : amount < 0 ? this.asks : this.bids
 
@@ -249,7 +242,7 @@ class OrderBook extends EventEmitter {
 
     // Match by price level, or order ID for raw books
     for (let i = 0; i < side.length; i++) {
-      if ((!raw && side[i][priceI] === price) || (raw && side[i][0] === oID)) {
+      if ((!raw && Number(side[i][priceI]) === price) || (raw && Number(side[i][0]) === oID)) {
         if ((!raw && count === 0) || (raw && price === 0)) {
           side.splice(i, 1) // remove
           this.emit('update', entry)
@@ -267,7 +260,7 @@ class OrderBook extends EventEmitter {
     }
 
     for (let i = 0; i < side.length; i++) {
-      pl = side[i]
+      pl = side[i].map((x) => Number(x))
 
       if (insertIndex === -1 && (
         (dir === -1 && price < pl[priceI]) || // by price
@@ -405,9 +398,6 @@ class OrderBook extends EventEmitter {
     return null
   }
 
-  /**
-   * @return {Array[]} - arr
-   */
   serialize () {
     return (this.asks || []).concat(this.bids || [])
   }
@@ -436,21 +426,21 @@ class OrderBook extends EventEmitter {
     const priceI = raw
       ? entry.length === 4 ? 2 : 1
       : 0
-    const price = entry[priceI]
-    const amount = entry.length === 4 ? entry[3] : entry[2]
+    const price = Number(entry[priceI])
+    const amount = entry.length === 4 ? Number(entry[3]) : Number(entry[2])
     const dir = entry.length === 4
       ? amount < 0 ? 1 : -1
       : amount < 0 ? -1 : 1
-    const count = raw ? -1 : entry.length === 4 ? entry[2] : entry[1]
+    const count = raw ? -1 : entry.length === 4 ? Number(entry[2]) : Number(entry[1])
     let insertIndex = -1
     let pl // price level
 
     for (let i = 0; i < ob.length; i++) {
-      pl = ob[i]
+      pl = ob[i].map((x) => Number(x))
 
       if (
         (!raw && pl[priceI] === price) ||
-        (raw && pl[0] === entry[0])
+        (raw && pl[0] === Number(entry[0]))
       ) {
         if ((!raw && count === 0) || (raw && price === 0)) {
           ob.splice(i, 1) // remove existing
@@ -468,14 +458,14 @@ class OrderBook extends EventEmitter {
     }
 
     for (let i = 0; i < ob.length; i++) {
-      pl = ob[i]
+      pl = ob[i].map((x) => Number(x))
 
       if (insertIndex === -1) {
         if (
           (dir === -1 && (pl.length === 4 ? -pl[3] : pl[2]) < 0 && price < pl[priceI]) || // by price
-          (dir === -1 && (pl.length === 4 ? -pl[3] : pl[2]) < 0 && price === pl[priceI] && (raw && entry[0] < pl[0])) || // by order ID
+          (dir === -1 && (pl.length === 4 ? -pl[3] : pl[2]) < 0 && price === pl[priceI] && (raw && Number(entry[0]) < pl[0])) || // by order ID
           (dir === 1 && (pl.length === 4 ? -pl[3] : pl[2]) > 0 && price > pl[priceI]) ||
-          (dir === 1 && (pl.length === 4 ? -pl[3] : pl[2]) > 0 && price === pl[priceI] && (raw && entry[0] < pl[0])) ||
+          (dir === 1 && (pl.length === 4 ? -pl[3] : pl[2]) > 0 && price === pl[priceI] && (raw && Number(entry[0]) < pl[0])) ||
           (dir === 1 && (pl.length === 4 ? -pl[3] : pl[2]) < 0)
         ) {
           insertIndex = i
@@ -494,12 +484,6 @@ class OrderBook extends EventEmitter {
     return true
   }
 
-  /**
-   * Resolves the mid-price of an array-format OB
-   *
-   * @param {Array[]} ob
-   * @param {boolean?} raw - default false
-   */
   static arrayOBMidPrice (ob = [], raw = false) {
     if (ob.length === 0) return null
 

--- a/lib/order_book.js
+++ b/lib/order_book.js
@@ -94,7 +94,7 @@ class OrderBook extends EventEmitter {
         let price = bid[0]
         const amount = bid.length === 4 ? bid[3] : bid[2]
         if (!raw && typeof price !== 'string') {
-          price =  Number(preparePrice(price))
+          price = Number(preparePrice(price))
           price = /e/.test(price + '')
             ? price.toFixed(Math.abs((price + '').split('e')[1]) + 1) // i.e. 1.7e-7 to fixed
             : price
@@ -107,7 +107,7 @@ class OrderBook extends EventEmitter {
         let price = ask[0]
         const amount = ask.length === 4 ? ask[3] : ask[2]
         if (!raw && typeof price !== 'string') {
-          price =  Number(preparePrice(price))
+          price = Number(preparePrice(price))
           price = /e/.test(price + '')
             ? price.toFixed(Math.abs((price + '').split('e')[1]) + 1) // i.e. 1.7e-7 to fixed
             : price
@@ -157,7 +157,7 @@ class OrderBook extends EventEmitter {
         let price = bid[0]
         const amount = bid.length === 4 ? bid[3] : bid[2]
         if (!raw && typeof price !== 'string') {
-          price =  Number(preparePrice(price))
+          price = Number(preparePrice(price))
           price = /e/.test(price + '')
             ? price.toFixed(Math.abs((price + '').split('e')[1]) + 1) // i.e. 1.7e-7 to fixed
             : price
@@ -169,7 +169,7 @@ class OrderBook extends EventEmitter {
         let price = ask[0]
         const amount = ask.length === 4 ? ask[3] : ask[2]
         if (!raw && typeof price !== 'string') {
-          price =  Number(preparePrice(price))
+          price = Number(preparePrice(price))
           price = /e/.test(price + '')
             ? price.toFixed(Math.abs((price + '').split('e')[1]) + 1) // i.e. 1.7e-7 to fixed
             : price

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=7"

--- a/test/lib/models/order_book.js
+++ b/test/lib/models/order_book.js
@@ -60,6 +60,26 @@ describe('OrderBook model', () => {
     assert.strictEqual(ob.checksum(), CRC.str('6000:1:6100:-3:5900:2:6200:-4'))
   })
 
+  it('checksum: returns expected value for high precision numbers', () => {
+    const ob = new OrderBook({
+      bids: [['0.000000001', 1, 1], ['0.0000000001', 1, '0.0000000002']],
+      asks: [['0.000000002', 1, -3], ['0.000000003', 1, -4]]
+    })
+
+    assert.strictEqual(ob.checksum(), CRC.str('0.000000001:1:0.000000002:-3:0.0000000001:0.0000000002:0.000000003:-4'))
+  })
+
+  it('updateWith: string update place the entry in the correct position in the book', () => {
+    const ob = new OrderBook({
+      bids: [['0.1', 1, 1], ['0.09', 1, '5']],
+      asks: [['0.2', 1, -3], ['0.3', 1, -4]]
+    })
+    ob.updateWith(['0.15', 1, -1])
+    ob.updateWith(['0.089', 1, 1])
+
+    assert.strictEqual(ob.checksum(), CRC.str('0.1:1:0.15:-1:0.09:5:0.2:-3:0.089:1:0.3:-4'))
+  })
+
   it('checksum: returns expected value for raw OB', () => {
     const ob = new OrderBook({
       bids: [[100, 6000, 1], [101, 6000, 2]], // first field is order ID here


### PR DESCRIPTION
### Description:
The original orderbook was only able to sort and generate a checksum if the entire book was in a float format. Due to floats causing precision problems we needed a way to store the book in a lossless high precision format. This pull request allows an orderbook to be created/updated and checksummed even though all data within the book is in string format.

### Breaking changes:
- None

### New features:
- [x] Create book with snapshot of string values
- [x] Update book with entry of string values
- [x] Generate checksum with string values

### Fixes:
- [x] Invalid checksum with high precision numbers: https://github.com/bitfinexcom/bitfinex-api-node/issues/511

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
