### PR TITLE
Feature: Support affiliate code in Order class 1.1.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.1.5
+- feature: support affiliateCode field in Order class
+
 # 1.1.4
 - feature: Login model
 

--- a/lib/order.js
+++ b/lib/order.js
@@ -2,6 +2,8 @@
 
 const Promise = require('bluebird')
 const _isFinite = require('lodash/isFinite')
+const _isString = require('lodash/isString')
+const _isEmpty = require('lodash/isEmpty')
 const { prepareAmount, preparePrice } = require('bfx-api-node-util')
 
 const Model = require('./model')
@@ -73,6 +75,7 @@ class Order extends Model {
    * @param {string} data.priceAuxLimit
    * @param {number|boolean} data.notify
    * @param {number} data.placedId
+   * @param {string?} data.affiliateCode
    * @param {Object?} apiInterface - saved for a later call to registerListeners()
    */
   constructor (data = {}, apiInterface) {
@@ -86,6 +89,7 @@ class Order extends Model {
       this.setOCO(data.oco, data.priceAuxLimit, data.cidOCO)
     }
 
+    this.affiliateCode = data.affiliateCode
     this._apiInterface = apiInterface
 
     this._onWSOrderNew = this._onWSOrderNew.bind(this)
@@ -462,6 +466,12 @@ class Order extends Model {
    * @return {Object} o
    */
   toNewOrderPacket () {
+    const meta = { ...(this.meta || {}) }
+
+    if (_isString(this.affiliateCode) && !_isEmpty(this.affiliateCode)) {
+      meta.aff_code = this.affiliateCode // eslint-disable-line
+    }
+
     const data = {
       gid: this.gid,
       cid: _isFinite(+this.cid) ? +this.cid : lastCID++,
@@ -469,7 +479,7 @@ class Order extends Model {
       type: this.type,
       amount: prepareAmount(+this.amount),
       flags: this.flags || 0,
-      meta: this.meta, // optional
+      meta,
 
       // optional, populated only for new orders; it is mtsTIF for existing orders
       tif: this.tif

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
Adds the ability to pass `affiliateCode` to the `Order` constructor (or set it manually), and then forwards it along in the new-order packet.

### New features:
- [ ] Order class affiliate code support

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
