### PR TITLE
Feature: Field validation, internal refactoring 1.2.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+	"presets": [
+		"env"
+	],
+	"plugins": [
+		"transform-regenerator",
+		"transform-object-rest-spread"
+	]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ todo
 package-lock.json
 .env
 /dist
+coverage
+.nyc_output
+tags

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
-# 1.1.10
+# 1.2.0
+- feature: add validation support to models
+- refactor: core Model() class method signatures to reduce boilerplate
+- Position feature: orderToClose() method
 
+# 1.1.10
 - feature: add ability to specify lev in new Order object
 
 # 1.1.9

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 # 1.2.0
+- meta: bumped dependencies
 - feature: add validation support to models
 - refactor: core Model() class method signatures to reduce boilerplate
 - Position feature: orderToClose() method

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 - feature: add validation support to models
 - refactor: core Model() class method signatures to reduce boilerplate
 - Position feature: orderToClose() method
+- Model fix: toJS() unserialize method invocation parameters
 
 # 1.1.10
 - feature: add ability to specify lev in new Order object

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 1.2.0
 - meta: bumped dependencies
+- meta: added husky pre-commit test hook
 - feature: add validation support to models
 - refactor: core Model() class method signatures to reduce boilerplate
 - Position feature: orderToClose() method

--- a/lib/alert.js
+++ b/lib/alert.js
@@ -1,6 +1,9 @@
 'use strict'
 
+const priceValidator = require('./validators/price')
+const symbolValidator = require('./validators/symbol')
 const Model = require('./model')
+
 const fields = {
   key: 0,
   type: 1,
@@ -29,6 +32,25 @@ class Alert extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+   * Validates a given alert instance
+   *
+    * TODO: validate type (get a list)
+   *
+   * @param {Object[]|Object|Alert[]|Alert|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        price: priceValidator,
+        symbol: symbolValidator
+      }
+    })
   }
 }
 

--- a/lib/alert.js
+++ b/lib/alert.js
@@ -1,15 +1,12 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   key: 0,
   type: 1,
   symbol: 2,
   price: 3
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Price alert model
@@ -23,15 +20,15 @@ class Alert extends Model {
    * @param {string} data.price
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 

--- a/lib/balance_info.js
+++ b/lib/balance_info.js
@@ -1,13 +1,10 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   amount: 0,
   amountNet: 1
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Wallet balance information model
@@ -19,15 +16,15 @@ class BalanceInfo extends Model {
    * @param {number} data.amountNet
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 

--- a/lib/balance_info.js
+++ b/lib/balance_info.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const amountValidator = require('./validators/amount')
 const Model = require('./model')
 const fields = {
   amount: 0,
@@ -25,6 +26,23 @@ class BalanceInfo extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+   * Validates a given balance info instance
+   *
+   * @param {Object[]|Object|BalanceInfo[]|BalanceInfo|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        amount: amountValidator,
+        amountNet: amountValidator
+      }
+    })
   }
 }
 

--- a/lib/candle.js
+++ b/lib/candle.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   mts: 0,
   open: 1,
   close: 2,
@@ -10,8 +9,6 @@ const FIELDS = {
   low: 4,
   volume: 5
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * OHLCV Candle model
@@ -27,15 +24,15 @@ class Candle extends Model {
    * @param {number} data.volume
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 

--- a/lib/candle.js
+++ b/lib/candle.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
 const Model = require('./model')
 const fields = {
   mts: 0,
@@ -33,6 +35,27 @@ class Candle extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+   * Validates a given Candle instance
+   *
+   * @param {Object[]|Object|Candle[]|Candle|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        mts: dateValidator,
+        open: numberValidator,
+        high: numberValidator,
+        low: numberValidator,
+        close: numberValidator,
+        volume: numberValidator
+      }
+    })
   }
 }
 

--- a/lib/currency.js
+++ b/lib/currency.js
@@ -1,16 +1,13 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   id: 0,
   name: 1,
   pool: 2,
   explorer: 3,
   symbol: 4
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Currency model
@@ -25,15 +22,15 @@ class Currency extends Model {
    * @param {string} data.symbol
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 

--- a/lib/currency.js
+++ b/lib/currency.js
@@ -1,6 +1,10 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const stringValidator = require('./validators/string')
+const currencyValidator = require('./validators/currency')
 const Model = require('./model')
+
 const fields = {
   id: 0,
   name: 1,
@@ -31,6 +35,27 @@ class Currency extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+   * Validates a given currency instance
+   *
+   * @param {Object[]|Object|Currency[]|Currency|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+
+      validators: {
+        id: numberValidator,
+        name: stringValidator,
+        pool: stringValidator,
+        explorer: stringValidator,
+        currency: currencyValidator
+      }
+    })
   }
 }
 

--- a/lib/funding_credit.js
+++ b/lib/funding_credit.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = ['notify', 'hidden', 'renew', 'noClose']
-const FIELDS = {
+
+const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
+const boolFields = ['notify', 'hidden', 'renew', 'noClose']
+const fields = {
   id: 0,
   symbol: 1,
   side: 2,
@@ -23,8 +25,6 @@ const FIELDS = {
   noClose: 20,
   positionPair: 21
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Funding Credit model
@@ -52,22 +52,19 @@ class FundingCredit extends Model {
    * @param {number|boolean} data.noClose
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields, boolFields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields, boolFields })
   }
 }
 
 FundingCredit.status = {}
-const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
-statuses.forEach((s) => {
-  FundingCredit.status[s.split(' ').join('_')] = s
-})
+statuses.forEach(s => (FundingCredit.status[s.split(' ').join('_')] = s))
 
 module.exports = FundingCredit

--- a/lib/funding_credit.js
+++ b/lib/funding_credit.js
@@ -1,5 +1,11 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const amountValidator = require('./validators/amount')
+const symbolValidator = require('./validators/symbol')
+const stringValidator = require('./validators/string')
+const dateValidator = require('./validators/date')
+const boolValidator = require('./validators/bool')
 const Model = require('./model')
 
 const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
@@ -61,6 +67,37 @@ class FundingCredit extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields, boolFields })
+  }
+
+  /**
+   * Validates a given fuding credit instance
+   *
+   * @param {Object[]|Object|FundingCredit[]|FundingCredit|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        mtsCreate: dateValidator,
+        mtsUpdate: dateValidator,
+        mtsOpening: dateValidator,
+        mtsLastPayout: dateValidator,
+        amount: amountValidator,
+        flags: numberValidator,
+        rate: numberValidator,
+        period: numberValidator,
+        rateReal: numberValidator,
+        notify: boolValidator,
+        hidden: boolValidator,
+        renew: boolValidator,
+        noClose: boolValidator,
+        status: stringValidator,
+        symbol: symbolValidator,
+        id: numberValidator
+      }
+    })
   }
 }
 

--- a/lib/funding_info.js
+++ b/lib/funding_info.js
@@ -1,11 +1,22 @@
 'use strict'
 
 const Model = require('./model')
+const isCollection = require('./util/is_collection')
+const _isArray = require('lodash/isArray')
 
 /**
  * Account Funding Info model
  */
 class FundingInfo extends Model {
+  /**
+   * Create a new instance from a data payload
+   *
+   * @param {Object[]|Object|Array[]|Array} data
+   */
+  constructor (data) {
+    super({ data })
+  }
+
   /**
    * Return an array representation of this model
    *
@@ -27,12 +38,20 @@ class FundingInfo extends Model {
   }
 
   /**
-   * @param {Object|Array} arr
+   * TODO: Figure out a better object key for 'payload', as we need to support
+   *       both arrays and POJOs
+   *
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    const [, symbol, data = []] = arr
-    const [yieldLoan, yieldLend, durationLoan, durationLend] = data
+  static unserialize (data) {
+    if (isCollection(data)) {
+      return data.map(FundingInfo.unserialize)
+    }
+
+    const symbol = _isArray(data) ? data[1] : data.symbol
+    const payload = (_isArray(data) ? data[2] : data.payload) || []
+    const [yieldLoan, yieldLend, durationLoan, durationLend] = payload
 
     return {
       symbol,

--- a/lib/funding_info.js
+++ b/lib/funding_info.js
@@ -1,8 +1,12 @@
 'use strict'
 
-const Model = require('./model')
-const isCollection = require('./util/is_collection')
 const _isArray = require('lodash/isArray')
+
+const numberValidator = require('./validators/number')
+const amountValidator = require('./validators/amount')
+const symbolValidator = require('./validators/symbol')
+const isCollection = require('./util/is_collection')
+const Model = require('./model')
 
 /**
  * Account Funding Info model
@@ -60,6 +64,24 @@ class FundingInfo extends Model {
       durationLoan,
       durationLend
     }
+  }
+
+  /**
+   * Validates a given funding info instance
+   *
+   * @param {Object[]|Object|FundingInfo[]|FundingInfo|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    const { symbol, yieldLoan, yieldLend, durationLoan, durationLend } = this
+
+    return (
+      symbolValidator(symbol) ||
+      amountValidator(yieldLoan) ||
+      amountValidator(yieldLend) ||
+      numberValidator(durationLoan) ||
+      numberValidator(durationLend)
+    )
   }
 }
 

--- a/lib/funding_loan.js
+++ b/lib/funding_loan.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = ['notify', 'hidden', 'renew', 'noClose']
-const FIELDS = {
+
+const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
+const boolFields = ['notify', 'hidden', 'renew', 'noClose']
+const fields = {
   id: 0,
   symbol: 1,
   side: 2,
@@ -22,8 +24,6 @@ const FIELDS = {
   rateReal: 19,
   noClose: 20
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Funding Loan model
@@ -50,15 +50,15 @@ class FundingLoan extends Model {
    * @param {number|boolean} data.noClose
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields, boolFields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields, boolFields })
   }
 }
 
@@ -68,9 +68,6 @@ FundingLoan.side = {
   LOAN: 'Loan'
 }
 
-const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
-statuses.forEach((s) => {
-  FundingLoan.status[s.split(' ').join('_')] = s
-})
+statuses.forEach(s => (FundingLoan.status[s.split(' ').join('_')] = s))
 
 module.exports = FundingLoan

--- a/lib/funding_loan.js
+++ b/lib/funding_loan.js
@@ -1,5 +1,11 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
+const amountValidator = require('./validators/amount')
+const boolValidator = require('./validators/bool')
+const stringValidator = require('./validators/string')
+const symbolValidator = require('./validators/symbol')
 const Model = require('./model')
 
 const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
@@ -59,6 +65,37 @@ class FundingLoan extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields, boolFields })
+  }
+
+  /**
+   * Validates a given funding loan instance
+   *
+   * @param {Object[]|Object|FundignLoan[]|FundignLoan|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        mtsCreate: dateValidator,
+        mtsUpdate: dateValidator,
+        mtsOpening: dateValidator,
+        mtsLastPayout: dateValidator,
+        amount: amountValidator,
+        flags: numberValidator,
+        rate: numberValidator,
+        period: numberValidator,
+        rateReal: numberValidator,
+        notify: boolValidator,
+        hidden: boolValidator,
+        renew: boolValidator,
+        noClose: boolValidator,
+        status: stringValidator,
+        symbol: symbolValidator,
+        id: numberValidator
+      }
+    })
   }
 }
 

--- a/lib/funding_offer.js
+++ b/lib/funding_offer.js
@@ -1,9 +1,11 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = ['notify', 'hidden', 'renew']
 const { prepareAmount } = require('bfx-api-node-util')
-const FIELDS = {
+
+const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
+const boolFields = ['notify', 'hidden', 'renew']
+const fields = {
   id: 0,
   symbol: 1,
   mtsCreate: 2,
@@ -20,8 +22,6 @@ const FIELDS = {
   renew: 19,
   rateReal: 20
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Funding Offer model
@@ -47,16 +47,16 @@ class FundingOffer extends Model {
    * @param {Object?} apiInterface - rest or websocket object capable of submitting funding offers
    */
   constructor (data = {}, apiInterface) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields, boolFields })
     this._apiInterface = apiInterface
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields, boolFields })
   }
 
   /**
@@ -77,42 +77,52 @@ class FundingOffer extends Model {
   }
 
   /**
-   * @param {WSv2|Rest2} apiInterface  - optional ws or rest, defaults to internal ws
+   * @param {WSv2|RESTv2?} apiInterface  - optional ws or rest, defaults to internal ws
    * @return {Promise} p
    */
-  submit (apiInterface = this._apiInterface) {
-    if (!apiInterface) return Promise.reject(new Error('no API interface provided'))
+  async submit (apiInterface = this._apiInterface) {
+    if (!apiInterface) {
+      throw new Error('no API interface provided')
+    }
 
-    return apiInterface.submitFundingOffer(this).then((offerArray) => {
-      Object.assign(this, FundingOffer.unserialize(offerArray))
-      return this
-    })
+    const offerArray = apiInterface.submitFundingOffer(this)
+
+    Object.assign(this, FundingOffer.unserialize(offerArray))
+
+    return this
   }
 
   /**
-   * @param {WSv2|Rest2} apiInterface  - optional ws or rest, defaults to internal ws
+   * @param {WSv2|RESTv2?} apiInterface  - optional ws or rest, defaults to internal ws
    * @return {Promise} p
    */
-  cancel (apiInterface = this._apiInterface) {
-    if (!apiInterface) return Promise.reject(new Error('no API interface provided'))
+  async cancel (apiInterface = this._apiInterface) {
+    if (!apiInterface) {
+      throw new Error('no API interface provided')
+    }
 
-    return apiInterface.cancelFundingOffer(this.id).then((offerArray) => {
-      Object.assign(this, FundingOffer.unserialize(offerArray))
-      return this
-    })
+    const offerArray = await apiInterface.cancelFundingOffer(this.id)
+
+    Object.assign(this, FundingOffer.unserialize(offerArray))
+
+    return this
   }
 
   /**
-   * @param {WSv2|Rest2} apiInterface  - optional ws or rest, defaults to internal ws
+   * @param {WSv2|RESTv2?} apiInterface  - optional ws or rest, defaults to internal ws
    * @return {Promise} p
    */
-  close (apiInterface = this._apiInterface) {
-    if (!apiInterface) return Promise.reject(new Error('no API interface provided'))
+  async close (apiInterface = this._apiInterface) {
+    if (!apiInterface) {
+      throw new Error('no API interface provided')
+    }
 
-    return apiInterface.closeFunding({ id: this.id, type: this.type }).then((offerArray) => {
-      Object.assign(this, FundingOffer.unserialize(offerArray))
-      return this
-    })
+    const { id, type } = this
+    const offerArray = await apiInterface.closeFunding({ id, type })
+
+    Object.assign(this, FundingOffer.unserialize(offerArray))
+
+    return this
   }
 }
 
@@ -122,9 +132,6 @@ FundingOffer.type = {
   LOAN: 'loan'
 }
 
-const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
-statuses.forEach((s) => {
-  FundingOffer.status[s.split(' ').join('_')] = s
-})
+statuses.forEach(s => (FundingOffer.status[s.split(' ').join('_')] = s))
 
 module.exports = FundingOffer

--- a/lib/funding_offer.js
+++ b/lib/funding_offer.js
@@ -1,7 +1,11 @@
 'use strict'
 
+const _filter = require('lodash/filter')
+const _flatten = require('lodash/flatten')
+const _isEmpty = require('lodash/isEmpty')
+const { RESTv2 } = require('bfx-api-node-rest')
+const { prepareAmount, preparePrice } = require('bfx-api-node-util')
 const Model = require('./model')
-const { prepareAmount } = require('bfx-api-node-util')
 
 const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
 const boolFields = ['notify', 'hidden', 'renew']
@@ -77,52 +81,82 @@ class FundingOffer extends Model {
   }
 
   /**
-   * @param {WSv2|RESTv2?} apiInterface  - optional ws or rest, defaults to internal ws
+   * Submit the funding offer
+   *
+   * @param {RESTv2} apiInterface  - optional rest instance
    * @return {Promise} p
    */
   async submit (apiInterface = this._apiInterface) {
-    if (!apiInterface) {
+    if (!(apiInterface instanceof RESTv2)) {
       throw new Error('no API interface provided')
     }
 
-    const offerArray = apiInterface.submitFundingOffer(this)
-
-    Object.assign(this, FundingOffer.unserialize(offerArray))
-
-    return this
+    return apiInterface.submitFundingOffer(this).then((offerArray) => {
+      Object.assign(this, FundingOffer.unserialize(offerArray))
+      return this
+    })
   }
 
   /**
-   * @param {WSv2|RESTv2?} apiInterface  - optional ws or rest, defaults to internal ws
+   * Cancel the funding offer
+   *
+   * @param {RESTv2} apiInterface  - optional rest instance
    * @return {Promise} p
    */
   async cancel (apiInterface = this._apiInterface) {
-    if (!apiInterface) {
+    if (!(apiInterface instanceof RESTv2)) {
       throw new Error('no API interface provided')
     }
 
-    const offerArray = await apiInterface.cancelFundingOffer(this.id)
-
-    Object.assign(this, FundingOffer.unserialize(offerArray))
-
-    return this
+    return apiInterface.cancelFundingOffer(this.id).then((offerArray) => {
+      Object.assign(this, FundingOffer.unserialize(offerArray))
+      return this
+    })
   }
 
   /**
-   * @param {WSv2|RESTv2?} apiInterface  - optional ws or rest, defaults to internal ws
+   * Close the funding offer
+   *
+   * @param {RESTv2} apiInterface  - optional rest instance
    * @return {Promise} p
    */
   async close (apiInterface = this._apiInterface) {
-    if (!apiInterface) {
+    if (!(apiInterface instanceof RESTv2)) {
       throw new Error('no API interface provided')
     }
 
-    const { id, type } = this
-    const offerArray = await apiInterface.closeFunding({ id, type })
+    return apiInterface.closeFunding({
+      id: this.id,
+      type: this.type
+    }).then((offerArray) => {
+      Object.assign(this, FundingOffer.unserialize(offerArray))
+      return this
+    })
+  }
 
-    Object.assign(this, FundingOffer.unserialize(offerArray))
+  /**
+   * Returns a string representation of the position
+   *
+   * @return {string} desc
+   */
+  toString () {
+    const {
+      id, symbol, status, amount, amountOrig, rate, period, renew
+    } = this
 
-    return this
+    return _filter(_flatten([
+      id && `(id: ${id})`,
+      'funding offer for',
+      symbol.substring(1),
+      !_isEmpty(status) && `(${status})`,
+      'for',
+      prepareAmount(amount),
+      (!!amountOrig && amountOrig !== amount) && `(${prepareAmount(amountOrig)})`,
+      '@',
+      preparePrice(rate),
+      `(period ${period})`,
+      `[renew ${renew ? 'Y' : 'N'}]`
+    ]), v => !!v).join(' ')
   }
 }
 

--- a/lib/funding_offer.js
+++ b/lib/funding_offer.js
@@ -5,6 +5,13 @@ const _flatten = require('lodash/flatten')
 const _isEmpty = require('lodash/isEmpty')
 const { RESTv2 } = require('bfx-api-node-rest')
 const { prepareAmount, preparePrice } = require('bfx-api-node-util')
+
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
+const amountValidator = require('./validators/amount')
+const boolValidator = require('./validators/bool')
+const stringValidator = require('./validators/string')
+const symbolValidator = require('./validators/symbol')
 const Model = require('./model')
 
 const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
@@ -157,6 +164,39 @@ class FundingOffer extends Model {
       `(period ${period})`,
       `[renew ${renew ? 'Y' : 'N'}]`
     ]), v => !!v).join(' ')
+  }
+
+  /**
+   * Validates a given funding offer instance
+   *
+   * @param {Object[]|Object|FundingOffer[]|FundingOffer|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        mtsCreate: dateValidator,
+        mtsUpdate: dateValidator,
+        mtsOpening: dateValidator,
+        mtsLastPayout: dateValidator,
+        amountOrig: amountValidator,
+        amount: amountValidator,
+        flags: numberValidator,
+        rate: numberValidator,
+        period: numberValidator,
+        rateReal: numberValidator,
+        notify: boolValidator,
+        hidden: boolValidator,
+        renew: boolValidator,
+        noClose: boolValidator,
+        status: stringValidator,
+        symbol: symbolValidator,
+        type: stringValidator,
+        id: numberValidator
+      }
+    })
   }
 }
 

--- a/lib/funding_ticker.js
+++ b/lib/funding_ticker.js
@@ -1,5 +1,10 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const amountValidator = require('./validators/amount')
+const symbolValidator = require('./validators/symbol')
+const priceValidator = require('./validators/price')
+const boolValidator = require('./validators/bool')
 const Model = require('./model')
 const fields = {
   symbol: 0,
@@ -63,6 +68,35 @@ class FundingTicker extends Model {
    */
   base () {
     return this.symbol.substring(1, 4)
+  }
+
+  /**
+   * Validates a given funding ticker instance
+   *
+   * @param {Object[]|Object|FundingTicker[]|FundingTicker|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        symbol: symbolValidator,
+        frr: boolValidator,
+        bid: priceValidator,
+        bidSize: amountValidator,
+        bidPeriod: numberValidator,
+        ask: priceValidator,
+        askSize: amountValidator,
+        askPeriod: numberValidator,
+        dailyChange: numberValidator,
+        dailyChangePerc: numberValidator,
+        lastPrice: priceValidator,
+        volume: numberValidator,
+        high: priceValidator,
+        low: priceValidator
+      }
+    })
   }
 }
 

--- a/lib/funding_ticker.js
+++ b/lib/funding_ticker.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   symbol: 0,
   frr: 1,
   bid: 2,
@@ -18,8 +17,6 @@ const FIELDS = {
   high: 12,
   low: 13
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Funding Ticker model
@@ -43,15 +40,15 @@ class FundingTicker extends Model {
    * @param {number} data.low
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 
   /**

--- a/lib/funding_ticker_hist.js
+++ b/lib/funding_ticker_hist.js
@@ -1,16 +1,13 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   symbol: 0,
   bid: 2,
   bidPeriod: 4,
   ask: 5,
   mtsUpdate: 15
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Historical Funding Ticker model
@@ -25,15 +22,15 @@ class FundingTickerHist extends Model {
    * @param {number} data.mtsUpdate
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 
   /**

--- a/lib/funding_ticker_hist.js
+++ b/lib/funding_ticker_hist.js
@@ -1,5 +1,9 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
+const symbolValidator = require('./validators/symbol')
+const priceValidator = require('./validators/price')
 const Model = require('./model')
 const fields = {
   symbol: 0,
@@ -45,6 +49,26 @@ class FundingTickerHist extends Model {
    */
   base () {
     return this.symbol.substring(1, 4)
+  }
+
+  /**
+   * Validates a given historical funding ticker instance
+   *
+   * @param {Object[]|Object|FundingTickerHist[]|FundingTickerHist|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        symbol: symbolValidator,
+        bid: priceValidator,
+        bidPeriod: numberValidator,
+        ask: priceValidator,
+        mtsUpdate: dateValidator
+      }
+    })
   }
 }
 

--- a/lib/funding_trade.js
+++ b/lib/funding_trade.js
@@ -1,5 +1,11 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
+const symbolValidator = require('./validators/symbol')
+const priceValidator = require('./validators/price')
+const amountValidator = require('./validators/amount')
+const boolValidator = require('./validators/bool')
 const _flatten = require('lodash/flatten')
 const _filter = require('lodash/filter')
 const Model = require('./model')
@@ -57,6 +63,29 @@ class FundingTrade extends Model {
       ['period', period],
       (typeof maker !== 'undefined') && maker ? 'maker' : 'taker'
     ]), v => !!v).join(' ')
+  }
+
+  /**
+   * Validates a given funding trade instance
+   *
+   * @param {Object[]|Object|FundingTrade[]|FundingTrade|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        id: numberValidator,
+        symbol: symbolValidator,
+        mtsCreate: dateValidator,
+        offerID: numberValidator,
+        amount: amountValidator,
+        rate: priceValidator,
+        period: numberValidator,
+        maker: boolValidator
+      }
+    })
   }
 }
 

--- a/lib/funding_trade.js
+++ b/lib/funding_trade.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const _flatten = require('lodash/flatten')
+const _filter = require('lodash/filter')
 const Model = require('./model')
 const fields = {
   id: 0,
@@ -37,6 +39,24 @@ class FundingTrade extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+    * @return {string}
+    */
+  toString () {
+    const {
+      id, symbol, mtsCreate, amount, rate, period, maker
+    } = this
+
+    return _filter(_flatten([
+      `(${id})`,
+      symbol,
+      new Date(mtsCreate).toLocaleString(),
+      [amount, '@', rate],
+      ['period', period],
+      (typeof maker !== 'undefined') && maker ? 'maker' : 'taker'
+    ]), v => !!v).join(' ')
   }
 }
 

--- a/lib/funding_trade.js
+++ b/lib/funding_trade.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   id: 0,
   symbol: 1,
   mtsCreate: 2,
@@ -12,8 +11,6 @@ const FIELDS = {
   period: 6,
   maker: 7
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Funding Trade model
@@ -31,15 +28,15 @@ class FundingTrade extends Model {
    * @param {number|boolean} data.maker
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,5 +28,7 @@ module.exports = {
   UserInfo: require('./user_info'),
   Currency: require('./currency'),
   StatusMessagesDeriv: require('./status_messages_deriv'),
-  Login: require('./login')
+  Login: require('./login'),
+
+  isCollection: require('./util/is_collection')
 }

--- a/lib/ledger_entry.js
+++ b/lib/ledger_entry.js
@@ -4,8 +4,7 @@ const _isString = require('lodash/isString')
 const _isEmpty = require('lodash/isEmpty')
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   id: 0,
   currency: 1,
   mts: 3,
@@ -14,8 +13,6 @@ const FIELDS = {
   description: 8,
   wallet: null
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Ledger Entry model; wallet field is automatically populated if a description
@@ -32,7 +29,7 @@ class LedgerEntry extends Model {
    * @param {string} data.description
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
 
     this.wallet = null
 
@@ -43,11 +40,11 @@ class LedgerEntry extends Model {
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 

--- a/lib/ledger_entry.js
+++ b/lib/ledger_entry.js
@@ -1,5 +1,10 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
+const amountValidator = require('./validators/amount')
+const currencyValidator = require('./validators/currency')
+const stringValidator = require('./validators/string')
 const _isString = require('lodash/isString')
 const _isEmpty = require('lodash/isEmpty')
 
@@ -45,6 +50,27 @@ class LedgerEntry extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+   * Validates a given ledger entry instance
+   *
+   * @param {Object[]|Object|LedgerEntry[]|LedgerEntry|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        id: numberValidator,
+        currency: currencyValidator,
+        mts: dateValidator,
+        amount: amountValidator,
+        balance: amountValidator,
+        description: stringValidator
+      }
+    })
   }
 }
 

--- a/lib/liquidations.js
+++ b/lib/liquidations.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   posId: 1,
   mtsUpdated: 2,
   symbol: 4,
@@ -11,8 +10,6 @@ const FIELDS = {
   isMatch: 8,
   isMarketSold: 9
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Liquidation Info model
@@ -29,15 +26,15 @@ class Liquidations extends Model {
    * @param {number|boolean} data.isMarketSold
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 

--- a/lib/liquidations.js
+++ b/lib/liquidations.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const _flatten = require('lodash/flatten')
+const _filter = require('lodash/filter')
 const Model = require('./model')
 const fields = {
   posId: 1,
@@ -35,6 +37,23 @@ class Liquidations extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+   * return {string}
+   */
+  toString () {
+    const {
+      mtsUpdated, symbol, amount, basePrice, isMatch, isMarketSold
+    } = this
+
+    return _filter(_flatten([
+      new Date(mtsUpdated).toLocaleString(),
+      symbol,
+      [amount, '@', basePrice],
+      isMatch && 'matched',
+      isMarketSold && 'sold'
+    ]), v => !!v).join(' ')
   }
 }
 

--- a/lib/liquidations.js
+++ b/lib/liquidations.js
@@ -1,5 +1,11 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
+const amountValidator = require('./validators/amount')
+const symbolValidator = require('./validators/symbol')
+const priceValidator = require('./validators/price')
+const boolValidator = require('./validators/bool')
 const _flatten = require('lodash/flatten')
 const _filter = require('lodash/filter')
 const Model = require('./model')
@@ -54,6 +60,28 @@ class Liquidations extends Model {
       isMatch && 'matched',
       isMarketSold && 'sold'
     ]), v => !!v).join(' ')
+  }
+
+  /**
+   * Validates a given liquidation instance
+   *
+   * @param {Object[]|Object|Liquidations[]|Liquidations|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        posId: numberValidator,
+        mtsUpdated: dateValidator,
+        symbol: symbolValidator,
+        amount: amountValidator,
+        basePrice: priceValidator,
+        isMatch: boolValidator,
+        isMarketSold: boolValidator
+      }
+    })
   }
 }
 

--- a/lib/login.js
+++ b/lib/login.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
+const stringValidator = require('./validators/string')
 const Model = require('./model')
 const fields = {
   id: 0,
@@ -29,6 +32,24 @@ class Login extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+   * Validates a given login instance
+   *
+   * @param {Object[]|Object|Login[]|Login|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        id: numberValidator,
+        time: dateValidator,
+        ip: stringValidator
+      }
+    })
   }
 }
 

--- a/lib/login.js
+++ b/lib/login.js
@@ -1,15 +1,12 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   id: 0,
   time: 2,
   ip: 4,
   extraData: 7
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * OHLCV Candle model
@@ -23,15 +20,15 @@ class Login extends Model {
    * @param {object} data.extraData
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]|Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 

--- a/lib/margin_info.js
+++ b/lib/margin_info.js
@@ -1,11 +1,22 @@
 'use strict'
 
 const Model = require('./model')
+const isCollection = require('./util/is_collection')
+const _isArray = require('lodash/isArray')
 
 /**
  * Margin Info model
  */
 class MarginInfo extends Model {
+  /**
+   * Create a new instance from a data payload
+   *
+   * @param {Object[]|Object|Array[]|Array} data
+   */
+  constructor (data) {
+    super({ data })
+  }
+
   /**
    * Return an array representation of this model
    *
@@ -26,31 +37,38 @@ class MarginInfo extends Model {
           marginNet
         ]
       ]
-    } else {
-      const { symbol, tradableBalance, grossBalance, buy, sell } = this
-
-      return [
-        type,
-        symbol,
-        [
-          tradableBalance,
-          grossBalance,
-          buy,
-          sell
-        ]
-      ]
     }
+
+    const { symbol, tradableBalance, grossBalance, buy, sell } = this
+
+    return [
+      type,
+      symbol,
+      [
+        tradableBalance,
+        grossBalance,
+        buy,
+        sell
+      ]
+    ]
   }
 
   /**
-   * @param {Array} arr
+   * TODO: Figure out a better object key for 'payload', as we need to support
+   *       both arrays and POJOs
+   *
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    const [type] = arr
+  static unserialize (data) {
+    if (isCollection(data)) {
+      return data.map(MarginInfo.unserialize)
+    }
+
+    const type = _isArray(data) ? data[0] : data.type
 
     if (type === 'base') {
-      const [, payload] = arr
+      const payload = (_isArray(data) ? data[1] : data.payload) || []
       const [userPL, userSwaps, marginBalance, marginNet] = payload
 
       return {
@@ -60,18 +78,19 @@ class MarginInfo extends Model {
         marginBalance,
         marginNet
       }
-    } else {
-      const [, symbol, payload] = arr
-      const [tradableBalance, grossBalance, buy, sell] = payload
+    }
 
-      return {
-        type,
-        symbol,
-        tradableBalance,
-        grossBalance,
-        buy,
-        sell
-      }
+    const symbol = _isArray(data) ? data[1] : data.symbol
+    const payload = (_isArray(data) ? data[2] : data.payload) || []
+    const [tradableBalance, grossBalance, buy, sell] = payload
+
+    return {
+      type,
+      symbol,
+      tradableBalance,
+      grossBalance,
+      buy,
+      sell
     }
   }
 }

--- a/lib/margin_info.js
+++ b/lib/margin_info.js
@@ -1,8 +1,13 @@
 'use strict'
 
-const Model = require('./model')
-const isCollection = require('./util/is_collection')
 const _isArray = require('lodash/isArray')
+
+const numberValidator = require('./validators/number')
+const amountValidator = require('./validators/amount')
+const symbolValidator = require('./validators/symbol')
+const stringValidator = require('./validators/string')
+const isCollection = require('./util/is_collection')
+const Model = require('./model')
 
 /**
  * Margin Info model
@@ -92,6 +97,25 @@ class MarginInfo extends Model {
       buy,
       sell
     }
+  }
+
+  /**
+   * Validates a given margin info instance
+   *
+   * @param {Object[]|Object|MarginInfo[]|MarginInfo|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    const { type, symbol, tradableBalance, grossBalance, buy, sell } = this
+
+    return (
+      stringValidator(type) ||
+      symbolValidator(symbol) ||
+      amountValidator(tradableBalance) ||
+      amountValidator(grossBalance) ||
+      numberValidator(buy) ||
+      numberValidator(sell)
+    )
   }
 }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,54 +1,36 @@
 'use strict'
 
 const { EventEmitter } = require('events')
+const isCollection = require('./util/is_collection')
+const assignFromCollectionOrInstance = require('./util/assign_from_collection_or_instance')
 const _isArray = require('lodash/isArray')
 const _isObject = require('lodash/isObject')
+const _isString = require('lodash/isString')
+const _isFunction = require('lodash/isFunction')
 
 /**
  * Base model class, providing format-conversion methods
  */
 class Model extends EventEmitter {
   /**
-   * @param {Object?} data - model data
-   * @param {Object?} fields - field definitions, { [index]: key }
-   * @param {Array?} boolFields - array of boolean field keys
-   * @param {Array?} fieldKeys - array of all field keys
+   * @param {Object} params
+   * @param {Object[]|Object|Array?} params.data - model data
+   * @param {Object?} params.fields - field definitions, { [index]: key }
+   * @param {string[]?} params.boolFields - array of boolean field keys, default empty
    */
-  constructor (data = {}, fields = {}, boolFields = [], fieldKeys = []) {
+  constructor ({ data, fields = {}, boolFields = [] } = {}) {
     super()
 
     this._fields = fields
     this._boolFields = boolFields
-    this._fieldKeys = fieldKeys
 
-    // Use/assign passed in data
-    if (!_isArray(data) && _isObject(data)) {
-      Object.assign(this, data)
-    } else if (_isArray(data) && data.length > 0) {
-      // Initialize iterator/setup array-like access if passed an array of model
-      // data.
-      if (_isArray(data[0]) || _isObject(data[0])) {
-        const collection = this.constructor.unserialize(data)
-        this._collection = collection
-
-        Object.assign(this, collection) // needed for [] access
-        this.length = collection.length
-
-        this[Symbol.iterator] = function () {
-          return {
-            _i: -1,
-            next: function () {
-              this._i++
-
-              return this._i === collection.length
-                ? { done: true }
-                : { value: collection[this._i], done: false }
-            }
-          }
-        }
-      } else {
-        Object.assign(this, this.constructor.unserialize(data))
-      }
+    if (_isObject(data) || _isArray(data)) {
+      assignFromCollectionOrInstance({
+        data,
+        fields,
+        boolFields,
+        target: this
+      })
     }
   }
 
@@ -58,11 +40,12 @@ class Model extends EventEmitter {
    * @return {Array} arr
    */
   serialize () {
+    const fieldKeys = Object.keys(this._fields)
     const arr = []
     let i, key
 
-    for (let j = 0; j < this._fieldKeys.length; j += 1) {
-      key = this._fieldKeys[j]
+    for (let j = 0; j < fieldKeys.length; j += 1) {
+      key = fieldKeys[j]
       i = this._fields[key]
       arr[i] = this[key]
 
@@ -80,30 +63,33 @@ class Model extends EventEmitter {
    * @return {Object} pojo
    */
   toJS () {
-    const arr = this.serialize()
-
-    return this.constructor.unserialize(
-      arr, this._fields, this._boolFields, this._fieldKeys
-    )
+    return this.constructor.unserialize({
+      data: this.serialize(),
+      boolFields: this._boolFields,
+      fields: this._fields
+    })
   }
 
   /**
    * Generic method for converting either an array, object, or model instance to
    * a POJO.
    *
-   * @param {Object|Array} data - can also be a model instance
-   * @param {Object} fields - field definitions, { [index]: key }
-   * @param {Array} boolFields - array of boolean field keys
-   * @param {Array} fieldKeys - array of all field keys
+   * @param {Object} args
+   * @param {Object[]|Object|Array} args.data - can also be a model instance
+   * @param {Object} args.fields - field definitions, { [index]: key }
+   * @param {string[]?} args.boolFields - array of boolean field keys, default empty
    * @return {Object} pojo
    */
-  static unserialize (data, fields, boolFields, fieldKeys) {
-    if (_isArray(data) && (_isArray(data[0]) || _isObject(data[0]))) {
-      return data.map(m => {
-        return Model.unserialize(m, fields, boolFields, fieldKeys)
-      })
+  static unserialize ({ data, fields, boolFields = [] }) {
+    if (isCollection(data)) {
+      return data.map(m => Model.unserialize({
+        data: m,
+        boolFields,
+        fields
+      }))
     }
 
+    const fieldKeys = Object.keys(fields)
     const obj = {}
 
     fieldKeys.forEach((key) => {
@@ -121,6 +107,53 @@ class Model extends EventEmitter {
     })
 
     return obj
+  }
+
+  /**
+   * Validates either a single model instance or a collection of model instances
+   * against a set of validation functions defined per-key.
+   *
+   * Returns the first error found.
+   *
+   * @param {Object} args
+   * @param {Object[]|Object|Array} args.data - model or collection to validate
+   * @param {Object} args.fields - map of fields to array indexes
+   * @param {Object} args.validators - map of field names to validation funcs
+   * @param {string[]?} args.boolFields - array of boolean field keys, default empty
+   * @return {Error|null} error - null if instance is valid
+   */
+  static validate ({ data, fields, boolFields = [], validators }) {
+    if (isCollection(data)) {
+      return data.map(i => Model.validate({
+        data: i,
+        fields,
+        boolFields,
+        validators
+      })).find(result => result instanceof Error) || null // return first error
+    }
+
+    const fieldKeys = Object.keys(fields)
+    const keys = Object.keys(validators)
+
+    let key
+    let instanceValue
+
+    for (let i = 0; i < keys.length; i += 1) {
+      key = keys[i]
+      instanceValue = _isArray(data)
+        ? data[fieldKeys[key]]
+        : data[key]
+
+      if (_isFunction(validators[key])) {
+        const errMessage = validators[key](instanceValue)
+
+        if (_isString(errMessage)) {
+          return new Error(`${key}: ${errMessage}`)
+        }
+      }
+    }
+
+    return null
   }
 }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -60,14 +60,10 @@ class Model extends EventEmitter {
   /**
    * Converts this model to object-format and returns the result
    *
-   * @return {Object} pojo
+   * @returns {Object} pojo
    */
   toJS () {
-    return this.constructor.unserialize({
-      data: this.serialize(),
-      boolFields: this._boolFields,
-      fields: this._fields
-    })
+    return this.constructor.unserialize(this.serialize())
   }
 
   /**

--- a/lib/movement.js
+++ b/lib/movement.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   id: 0,
   currency: 1,
   currencyName: 2,
@@ -14,8 +13,6 @@ const FIELDS = {
   destinationAddress: 16,
   transactionId: 20
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Currency Movement model
@@ -35,15 +32,15 @@ class Movement extends Model {
    * @param {number} data.transactionId
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 

--- a/lib/movement.js
+++ b/lib/movement.js
@@ -1,5 +1,10 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
+const amountValidator = require('./validators/amount')
+const currencyValidator = require('./validators/currency')
+const stringValidator = require('./validators/string')
 const Model = require('./model')
 const fields = {
   id: 0,
@@ -41,6 +46,31 @@ class Movement extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+   * Validates a given movement instance
+   *
+   * @param {Object[]|Object|Movement[]|Movement|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        id: numberValidator,
+        currency: currencyValidator,
+        currencyName: stringValidator,
+        mtsStarted: dateValidator,
+        mtsUpdated: dateValidator,
+        status: stringValidator,
+        amount: amountValidator,
+        fees: numberValidator,
+        destinationAddress: stringValidator,
+        transactionId: stringValidator
+      }
+    })
   }
 }
 

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
+const stringValidator = require('./validators/string')
 const Model = require('./model')
 const fields = {
   mts: 0,
@@ -35,6 +38,27 @@ class Notification extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+   * Validates a given notification instance
+   *
+   * @param {Object[]|Object|Notification[]|Notification|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        mts: dateValidator,
+        type: stringValidator,
+        messageID: numberValidator,
+        code: numberValidator,
+        status: stringValidator,
+        text: stringValidator
+      }
+    })
   }
 }
 

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   mts: 0,
   type: 1,
   messageID: 2,
@@ -11,8 +10,6 @@ const FIELDS = {
   status: 6,
   text: 7
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Notification model
@@ -29,15 +26,15 @@ class Notification extends Model {
    * @param {string} data.text
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 

--- a/lib/order.js
+++ b/lib/order.js
@@ -8,6 +8,13 @@ const _filter = require('lodash/filter')
 const _flatten = require('lodash/flatten')
 const { prepareAmount, preparePrice } = require('bfx-api-node-util')
 
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
+const amountValidator = require('./validators/amount')
+const stringValidator = require('./validators/string')
+const boolValidator = require('./validators/bool')
+const priceValidator = require('./validators/price')
+const symbolValidator = require('./validators/symbol')
 const Model = require('./model')
 
 const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
@@ -595,6 +602,41 @@ class Order extends Model {
    */
   static getQuoteCurrency (arr = []) {
     return (arr[3] || '').substring(4).toUpperCase()
+  }
+
+  /**
+   * Validates a given order instance
+   *
+   * @param {Object[]|Object|Order[]|Order|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        symbol: symbolValidator,
+        id: numberValidator,
+        gid: numberValidator,
+        cid: dateValidator,
+        mtsCreate: dateValidator,
+        mtsUpdate: dateValidator,
+        amount: amountValidator,
+        amountOrig: amountValidator,
+        type: v => stringValidator(v, Object.values(Order.type)),
+        typePrev: v => stringValidator(v, Object.values(Order.type)),
+        mtsTIF: dateValidator,
+        flags: numberValidator,
+        status: stringValidator,
+        price: priceValidator,
+        priceAvg: priceValidator,
+        priceTrailing: priceValidator,
+        priceAuxLimit: priceValidator,
+        notify: boolValidator,
+        hidden: boolValidator,
+        placedId: numberValidator
+      }
+    })
   }
 }
 

--- a/lib/order.js
+++ b/lib/order.js
@@ -10,8 +10,15 @@ const { prepareAmount, preparePrice } = require('bfx-api-node-util')
 
 const Model = require('./model')
 
-const BOOL_FIELDS = ['notify']
-const FIELDS = {
+const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
+const types = [
+  'MARKET', 'EXCHANGE MARKET', 'LIMIT', 'EXCHANGE LIMIT', 'STOP',
+  'EXCHANGE STOP', 'TRAILING STOP', 'EXCHANGE TRAILING STOP', 'FOK',
+  'EXCHANGE FOK', 'STOP LIMIT', 'EXCHANGE STOP LIMIT'
+]
+
+const boolFields = ['notify']
+const fields = {
   id: 0,
   gid: 1,
   cid: 2,
@@ -47,8 +54,6 @@ const FIELDS = {
   meta: 31
 }
 
-const FIELD_KEYS = Object.keys(FIELDS)
-
 let lastCID = Date.now()
 
 /**
@@ -82,7 +87,7 @@ class Order extends Model {
    * @param {Object?} apiInterface - saved for a later call to registerListeners()
    */
   constructor (data = {}, apiInterface) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields, boolFields })
 
     if (!this.flags) this.flags = 0
     if (typeof data.hidden !== 'undefined') this.setHidden(data.hidden)
@@ -108,11 +113,11 @@ class Order extends Model {
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields, boolFields })
   }
 
   /**
@@ -197,6 +202,7 @@ class Order extends Model {
   /**
    * @param {boolean} v
    * @param {number?} stopPrice - optional, defaults to current value
+   * @return {number} finalFlags
    */
   setOCO (v, stopPrice = this.priceAuxLimit, cidOCO = this.cidOCO) {
     if (v) {
@@ -204,48 +210,64 @@ class Order extends Model {
       this.cidOCO = cidOCO
     }
 
-    this._modifyFlag(Order.flags.OCO, v)
+    return this.modifyFlag(Order.flags.OCO, v)
   }
 
   /**
    * @param {boolean} v
+   * @return {number} finalFlags
    */
   setHidden (v) {
-    this._modifyFlag(Order.flags.HIDDEN, v)
+    return this.modifyFlag(Order.flags.HIDDEN, v)
   }
 
   /**
    * @param {boolean} v
+   * @return {number} finalFlags
    */
   setPostOnly (v) {
-    this._modifyFlag(Order.flags.POSTONLY, v)
+    return this.modifyFlag(Order.flags.POSTONLY, v)
   }
 
   /**
    * @param {boolean} v
+   * @return {number} finalFlags
    */
   setNoVariableRates (v) {
-    this._modifyFlag(Order.flags.NO_VR, v)
+    return this.modifyFlag(Order.flags.NO_VR, v)
   }
 
   /**
    * @param {boolean} v
+   * @return {number} finalFlags
    */
   setPositionClose (v) {
-    this._modifyFlag(Order.flags.POS_CLOSE, v)
+    return this.modifyFlag(Order.flags.POS_CLOSE, v)
   }
 
   /**
    * @param {boolean} v
+   * @return {number} finalFlags
    */
   setReduceOnly (v) {
-    this._modifyFlag(Order.flags.REDUCE_ONLY, v)
+    return this.modifyFlag(Order.flags.REDUCE_ONLY, v)
   }
 
-  _modifyFlag (flag, active) {
-    if (!!(this.flags & flag) === active) return
+  /**
+   * Updates a specific flag
+   *
+   * @param {number} flag - flag value
+   * @param {boolean} active - active status
+   * @return {number} finalFlags
+   */
+  modifyFlag (flag, active) {
+    if (!!(this.flags & flag) === active) {
+      return
+    }
 
     this.flags += active ? flag : -flag
+
+    return this.flags
   }
 
   /**
@@ -260,14 +282,18 @@ class Order extends Model {
    * @param {WSv2|Rest2} apiInterface - optional ws or rest, defaults to internal instance
    * @return {Promise} p - resolves on ws2 confirmation or rest response
    */
-  update (changes = {}, apiInterface = this._apiInterface) {
+  async update (changes = {}, apiInterface = this._apiInterface) {
+    if (!apiInterface) {
+      throw new Error('no ws client available')
+    }
+
     const keys = Object.keys(changes)
 
     // Apply change locally
     keys.forEach(k => {
       if (k === 'id') return
 
-      if (FIELD_KEYS.indexOf(k) !== -1) {
+      if (Object.keys(this._fields).indexOf(k) !== -1) {
         this[k] = changes[k]
       } else if (k === 'price_trailing') {
         this.priceTrailing = Number(changes[k])
@@ -296,9 +322,7 @@ class Order extends Model {
       changes.price_trailing = preparePrice(changes.price_trailing)
     }
 
-    return apiInterface
-      ? apiInterface.updateOrder(changes)
-      : Promise.reject(new Error('no ws client available'))
+    return apiInterface.updateOrder(changes)
   }
 
   /**
@@ -352,7 +376,9 @@ class Order extends Model {
    * @param {WSv2|Rest2} apiInterface - optional ws defaults to internal ws
    */
   removeListeners (apiInterface = this._apiInterface) {
-    if (apiInterface) apiInterface.removeListeners(this.cbGID())
+    if (apiInterface) {
+      apiInterface.removeListeners(this.cbGID())
+    }
   }
 
   /**
@@ -366,22 +392,23 @@ class Order extends Model {
    * @param {WSv2|Rest2} apiInterface - optional ws or rest, defaults to internal ws
    * @return {Promise} p
    */
-  submit (apiInterface = this._apiInterface) {
-    if (!apiInterface) return Promise.reject(new Error('no API interface provided'))
+  async submit (apiInterface = this._apiInterface) {
+    if (!apiInterface) {
+      throw new Error('no API interface provided')
+    }
 
-    return apiInterface.submitOrder(this).then((orderArr) => {
-      Object.assign(this, Order.unserialize(orderArr))
-      return this
-    })
+    const orderArr = await apiInterface.submitOrder(this)
+    Object.assign(this, Order.unserialize(orderArr))
+    return this
   }
 
   /**
    * @param {WSv2|Rest2} apiInterface - optional ws or rest, defaults to internal ws
    * @return {Promise} p
    */
-  cancel (apiInterface = this._apiInterface) {
-    if (!apiInterface) return Promise.reject(new Error('no API interface provided'))
-    if (!this.id) return Promise.reject(new Error('order has no ID'))
+  async cancel (apiInterface = this._apiInterface) {
+    if (!apiInterface) throw new Error('no API interface provided')
+    if (!this.id) throw new Error('order has no ID')
 
     return apiInterface.cancelOrder(this.id)
   }
@@ -392,15 +419,15 @@ class Order extends Model {
    * @param {WSv2|Rest2} apiInterface - optional ws or rest, defaults to internal ws
    * @return {Promise} p
    */
-  recreate (apiInterface = this._apiInterface) {
-    if (!apiInterface) return Promise.reject(new Error('no API interface provided'))
-    if (!this.id) return Promise.reject(new Error('order has no ID'))
+  async recreate (apiInterface = this._apiInterface) {
+    if (!apiInterface) throw new Error('no API interface provided')
+    if (!this.id) throw new Error('order has no ID')
 
-    return this.cancel(apiInterface).then(() => {
-      this.id = null
+    await this.cancel(apiInterface)
 
-      return this.submit(apiInterface)
-    })
+    this.id = null
+
+    return this.submit(apiInterface)
   }
 
   /**
@@ -573,13 +600,6 @@ class Order extends Model {
 
 Order.type = {}
 Order.status = {}
-
-const statuses = ['ACTIVE', 'EXECUTED', 'PARTIALLY FILLED', 'CANCELED']
-const types = [
-  'MARKET', 'EXCHANGE MARKET', 'LIMIT', 'EXCHANGE LIMIT', 'STOP',
-  'EXCHANGE STOP', 'TRAILING STOP', 'EXCHANGE TRAILING STOP', 'FOK',
-  'EXCHANGE FOK', 'STOP LIMIT', 'EXCHANGE STOP LIMIT'
-]
 
 statuses.forEach((s) => {
   Order.status[s] = s

--- a/lib/order.js
+++ b/lib/order.js
@@ -351,7 +351,7 @@ class Order extends Model {
    * @param {Object} apiInterface - optional, defaults to internal ws
    */
   registerListeners (apiInterface = this._apiInterface) {
-    if (!apiInterface) return
+    if (!apiInterface || apiInterface.constructor.name !== 'WSv2') return
 
     const chanData = {
       symbol: this.symbol,

--- a/lib/order_book.js
+++ b/lib/order_book.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const { EventEmitter } = require('events')
 const CRC = require('crc-32')
+const { EventEmitter } = require('events')
 const _isEmpty = require('lodash/isEmpty')
-
 const { preparePrice } = require('bfx-api-node-util')
 
 /**

--- a/lib/position.js
+++ b/lib/position.js
@@ -4,6 +4,13 @@ const _filter = require('lodash/filter')
 const _flatten = require('lodash/flatten')
 const _isEmpty = require('lodash/isEmpty')
 const { prepareAmount, preparePrice } = require('bfx-api-node-util')
+
+const numberValidator = require('./validators/number')
+const symbolValidator = require('./validators/symbol')
+const stringValidator = require('./validators/string')
+const amountValidator = require('./validators/amount')
+const priceValidator = require('./validators/price')
+const dateValidator = require('./validators/date')
 const Model = require('./model')
 const Order = require('./order')
 
@@ -146,6 +153,37 @@ class Position extends Model {
       preparePrice(liquidationPrice),
       `[funding ${prepareAmount(marginFunding)}]`
     ]), v => !!v).join(' ')
+  }
+
+  /**
+   * Validates a given position instance
+   *
+   * @param {Object[]|Object|Position[]|Position|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        symbol: symbolValidator,
+        status: stringValidator,
+        amount: amountValidator,
+        basePrice: priceValidator,
+        marginFunding: numberValidator,
+        marginFundingType: stringValidator,
+        pl: numberValidator,
+        plPerc: numberValidator,
+        liquidationPrice: numberValidator,
+        leverage: numberValidator,
+        id: numberValidator,
+        mtsCreate: dateValidator,
+        mtsUpdate: dateValidator,
+        type: stringValidator,
+        collateral: numberValidator,
+        collateralMin: numberValidator
+      }
+    })
   }
 }
 

--- a/lib/position.js
+++ b/lib/position.js
@@ -1,5 +1,9 @@
 'use strict'
 
+const _filter = require('lodash/filter')
+const _flatten = require('lodash/flatten')
+const _isEmpty = require('lodash/isEmpty')
+const { prepareAmount, preparePrice } = require('bfx-api-node-util')
 const Model = require('./model')
 const Order = require('./order')
 
@@ -64,15 +68,36 @@ class Position extends Model {
   }
 
   /**
-   * @param {WSv2|Rest2} apiInterface - optional ws or rest, defaults to internal ws
+   * Claim the position
+   *
+   * @param {RESTv2} apiInterface - optional rest, defaults to internal interface
    * @return {Promise} p
    */
   async claim (apiInterface = this._apiInterface) {
-    if (!apiInterface) throw new Error('no claim handler')
+    if (!apiInterface.claimPosition) {
+      throw new Error('claim position only supported on RESTv2')
+    }
 
-    const positionArray = await apiInterface.claimPosition(this.id)
-    Object.assign(this, Position.unserialize(positionArray))
-    return this
+    return apiInterface.claimPosition(this.id).then((positionArray) => {
+      Object.assign(this, Position.unserialize(positionArray))
+      return this
+    })
+  }
+
+  /**
+   * Close the position
+   *
+   * @param {RESTv2} apiInterface - optional rest, defaults to internal interface
+   * @return {Promise} p
+   */
+  async close (apiInterface = this._apiInterface) {
+    if (!apiInterface.closePosition) {
+      throw new Error('close position only supported on RESTv2')
+    }
+
+    return apiInterface.closePosition({
+      position_id: this.id // eslint-disable-line
+    })
   }
 
   /**
@@ -90,6 +115,37 @@ class Position extends Model {
       amount: +amount * -1,
       flags: Order.flags.REDUCE_ONLY | Order.flags.POS_CLOSE
     }, this._apiInterface)
+  }
+
+  /**
+   * Returns a string representation of the position
+   *
+   * @return {string} desc
+   */
+  toString () {
+    const {
+      symbol = '', amount, price, status, id, basePrice, marginFunding, pl,
+      liquidationPrice
+    } = this
+
+    const market = `${symbol.substring(1, 4)}/${symbol.substring(4)}`
+
+    return _filter(_flatten([
+      id && `(id: ${id})`,
+      'position on',
+      market,
+      !_isEmpty(status) && `(${status})`,
+      'for',
+      prepareAmount(amount),
+      '@',
+      preparePrice(price),
+      `(base price ${preparePrice(basePrice)})`,
+      'pl',
+      prepareAmount(pl),
+      'liq',
+      preparePrice(liquidationPrice),
+      `[funding ${prepareAmount(marginFunding)}]`
+    ]), v => !!v).join(' ')
   }
 }
 

--- a/lib/position.js
+++ b/lib/position.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+
+const statuses = ['ACTIVE', 'CLOSED']
+const fields = {
   symbol: 0,
   status: 1,
   amount: 2,
@@ -21,8 +22,6 @@ const FIELDS = {
   collateralMin: 18,
   meta: 19
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Position model
@@ -51,37 +50,32 @@ class Position extends Model {
    * @param {WSv2|Rest2} apiInterface - optional, rest or websocket object thats capable of submitting position changes
   */
   constructor (data = {}, apiInterface) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
     this._apiInterface = apiInterface
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 
   /**
    * @param {WSv2|Rest2} apiInterface - optional ws or rest, defaults to internal ws
    * @return {Promise} p
    */
-  claim (apiInterface = this._apiInterface) {
-    if (!apiInterface) return Promise.reject(new Error('no claim handler'))
+  async claim (apiInterface = this._apiInterface) {
+    if (!apiInterface) throw new Error('no claim handler')
 
-    apiInterface.claimPosition(this.id)
-      .then((positionArray) => {
-        Object.assign(this, Position.unserialize(positionArray))
-        return this
-      })
+    const positionArray = await apiInterface.claimPosition(this.id)
+    Object.assign(this, Position.unserialize(positionArray))
+    return this
   }
 }
 
 Position.status = {}
-const statuses = ['ACTIVE', 'CLOSED']
-statuses.forEach((s) => {
-  Position.status[s] = s
-})
+statuses.forEach(s => (Position.status[s] = s))
 
 module.exports = Position

--- a/lib/position.js
+++ b/lib/position.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Model = require('./model')
+const Order = require('./order')
 
 const statuses = ['ACTIVE', 'CLOSED']
 const fields = {
@@ -72,6 +73,23 @@ class Position extends Model {
     const positionArray = await apiInterface.claimPosition(this.id)
     Object.assign(this, Position.unserialize(positionArray))
     return this
+  }
+
+  /**
+   * Generate an order that can be used to close the position
+   *
+   * @param {WSv2|Rest2} apiInterface - optional ws or rest
+   * @return {Promise} p
+   */
+  orderToClose (apiInterface) {
+    const { symbol, amount } = this
+
+    return new Order({
+      symbol,
+      type: Order.type.MARKET,
+      amount: +amount * -1,
+      flags: Order.flags.REDUCE_ONLY | Order.flags.POS_CLOSE
+    }, this._apiInterface)
   }
 }
 

--- a/lib/public_trade.js
+++ b/lib/public_trade.js
@@ -3,7 +3,7 @@
 const _isArray = require('lodash/isArray')
 const _isObject = require('lodash/isObject')
 const Model = require('./model')
-const BOOL_FIELDS = []
+
 const TRADING_FIELDS = {
   id: 0,
   mts: 1,
@@ -19,9 +19,6 @@ const FUNDING_FIELDS = {
   period: 4
 }
 
-const TRADING_FIELD_KEYS = Object.keys(TRADING_FIELDS)
-const FUNDING_FIELD_KEYS = Object.keys(FUNDING_FIELDS)
-
 /**
  * Public Trade model, supporting both funding & ordinary trades
  */
@@ -32,15 +29,15 @@ class PublicTrade extends Model {
   constructor (data = {}) {
     if (_isArray(data)) {
       if (data.length === 5) {
-        super(data, FUNDING_FIELDS, BOOL_FIELDS, FUNDING_FIELD_KEYS)
+        super({ data, fields: FUNDING_FIELDS })
       } else {
-        super(data, TRADING_FIELDS, BOOL_FIELDS, TRADING_FIELD_KEYS)
+        super({ data, fields: TRADING_FIELDS })
       }
     } else if (_isObject(data)) {
       if (data.rate) {
-        super(data, FUNDING_FIELDS, BOOL_FIELDS, FUNDING_FIELD_KEYS)
+        super({ data, fields: FUNDING_FIELDS })
       } else {
-        super(data, TRADING_FIELDS, BOOL_FIELDS, TRADING_FIELD_KEYS)
+        super({ data, fields: TRADING_FIELDS })
       }
     } else {
       throw new Error('unknown data type')
@@ -48,14 +45,14 @@ class PublicTrade extends Model {
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    if ((_isArray(arr[0]) && arr[0].length === 5) || (arr.length === 5)) {
-      return super.unserialize(arr, FUNDING_FIELDS, BOOL_FIELDS, FUNDING_FIELD_KEYS)
+  static unserialize (data) {
+    if ((_isArray(data[0]) && data[0].length === 5) || (data.length === 5)) {
+      return super.unserialize({ data, fields: FUNDING_FIELDS })
     } else {
-      return super.unserialize(arr, TRADING_FIELDS, BOOL_FIELDS, TRADING_FIELD_KEYS)
+      return super.unserialize({ data, fields: TRADING_FIELDS })
     }
   }
 }

--- a/lib/public_trade.js
+++ b/lib/public_trade.js
@@ -83,7 +83,7 @@ class PublicTrade extends Model {
    * @return {string} error - null if instance is valid
    */
   static validate (data) {
-    const { rate } = this
+    const { rate } = data
 
     return super.validate({
       data,

--- a/lib/public_trade.js
+++ b/lib/public_trade.js
@@ -3,6 +3,12 @@
 const _flatten = require('lodash/flatten')
 const _isArray = require('lodash/isArray')
 const _isObject = require('lodash/isObject')
+const _isFinite = require('lodash/isFinite')
+
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
+const amountValidator = require('./validators/amount')
+const priceValidator = require('./validators/price')
 const Model = require('./model')
 
 const TRADING_FIELDS = {
@@ -68,6 +74,33 @@ class PublicTrade extends Model {
       new Date(mts).toLocaleString(),
       [amount, '@', price]
     ]).join(' ')
+  }
+
+  /**
+   * Validates a given public trade instance
+   *
+   * @param {Object[]|Object|PublicTrade[]|PublicTrade|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    const { rate } = this
+
+    return super.validate({
+      data,
+      fields: _isFinite(rate) ? FUNDING_FIELDS : TRADING_FIELDS,
+      validators: _isFinite(rate) ? {
+        id: numberValidator,
+        mts: dateValidator,
+        amount: amountValidator,
+        rate: priceValidator,
+        period: numberValidator
+      } : {
+        id: numberValidator,
+        mts: dateValidator,
+        amount: amountValidator,
+        price: priceValidator
+      }
+    })
   }
 }
 

--- a/lib/public_trade.js
+++ b/lib/public_trade.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const _flatten = require('lodash/flatten')
 const _isArray = require('lodash/isArray')
 const _isObject = require('lodash/isObject')
 const Model = require('./model')
@@ -54,6 +55,19 @@ class PublicTrade extends Model {
     } else {
       return super.unserialize({ data, fields: TRADING_FIELDS })
     }
+  }
+
+  /**
+    * @return {string}
+    */
+  toString () {
+    const { id, mts, amount, price } = this
+
+    return _flatten([
+      `(${id})`,
+      new Date(mts).toLocaleString(),
+      [amount, '@', price]
+    ]).join(' ')
   }
 }
 

--- a/lib/status_messages_deriv.js
+++ b/lib/status_messages_deriv.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+
+const fields = {
   key: 0,
   timestamp: 1,
   price: 3,
@@ -11,8 +11,6 @@ const FIELDS = {
   fundingAccrued: 9,
   fundingStep: 10
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Derivatives Status Message model
@@ -29,15 +27,15 @@ class StatusMessagesDeriv extends Model {
    * @param {string} data.fundingStep
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 

--- a/lib/status_messages_deriv.js
+++ b/lib/status_messages_deriv.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const stringValidator = require('./validators/string')
+const priceValidator = require('./validators/price')
 const Model = require('./model')
 
 const fields = {
@@ -36,6 +38,28 @@ class StatusMessagesDeriv extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+   * Validates a given public trade instance
+   *
+   * @param {Object[]|Object|PublicTrade[]|PublicTrade|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        key: stringValidator,
+        timestamp: stringValidator,
+        price: priceValidator,
+        priceSpot: priceValidator,
+        fundBal: priceValidator,
+        fundingAccrued: priceValidator,
+        fundingStep: priceValidator
+      }
+    })
   }
 }
 

--- a/lib/trade.js
+++ b/lib/trade.js
@@ -3,6 +3,16 @@
 const _isFinite = require('lodash/isFinite')
 const _flatten = require('lodash/flatten')
 const _filter = require('lodash/filter')
+
+const numberValidator = require('./validators/number')
+const dateValidator = require('./validators/date')
+const amountValidator = require('./validators/amount')
+const currencyValidator = require('./validators/currency')
+const stringValidator = require('./validators/string')
+const priceValidator = require('./validators/price')
+const boolValidator = require('./validators/bool')
+const symbolValidator = require('./validators/symbol')
+const Order = require('./order')
 const Model = require('./model')
 
 const boolFields = ['maker']
@@ -66,6 +76,32 @@ class Trade extends Model {
       (typeof maker !== 'undefined') && maker ? 'maker' : 'taker',
       _isFinite(fee) && [fee, feeCurrency]
     ]), v => !!v).join(' ')
+  }
+
+  /**
+   * Validates a given trade instance
+   *
+   * @param {Object[]|Object|PublicTrade[]|PublicTrade|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        id: numberValidator,
+        symbol: symbolValidator,
+        mtsCreate: dateValidator,
+        orderID: stringValidator,
+        execAmount: amountValidator,
+        execPrice: priceValidator,
+        orderType: v => stringValidator(v, Object.values(Order.type)),
+        orderPrice: priceValidator,
+        maker: boolValidator,
+        fee: numberValidator,
+        feeCurrency: currencyValidator
+      }
+    })
   }
 }
 

--- a/lib/trade.js
+++ b/lib/trade.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = ['maker']
-const FIELDS = {
+
+const boolFields = ['maker']
+const fields = {
   id: 0,
   symbol: 1,
   mtsCreate: 2,
@@ -15,8 +16,6 @@ const FIELDS = {
   fee: 9,
   feeCurrency: 10
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Private Trade model
@@ -37,15 +36,15 @@ class Trade extends Model {
    * @param {string} data.feeCurrency
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields, boolFields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields, boolFields })
   }
 }
 

--- a/lib/trade.js
+++ b/lib/trade.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const _isFinite = require('lodash/isFinite')
+const _flatten = require('lodash/flatten')
+const _filter = require('lodash/filter')
 const Model = require('./model')
 
 const boolFields = ['maker']
@@ -45,6 +48,24 @@ class Trade extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields, boolFields })
+  }
+
+  /**
+    * @return {string}
+    */
+  toString () {
+    const {
+      id, symbol, mtsCreate, execAmount, execPrice, maker, fee, feeCurrency
+    } = this
+
+    return _filter(_flatten([
+      `(${id})`,
+      symbol,
+      new Date(mtsCreate).toLocaleString(),
+      [execAmount, '@', execPrice],
+      (typeof maker !== 'undefined') && maker ? 'maker' : 'taker',
+      _isFinite(fee) && [fee, feeCurrency]
+    ]), v => !!v).join(' ')
   }
 }
 

--- a/lib/trading_ticker.js
+++ b/lib/trading_ticker.js
@@ -1,5 +1,9 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const amountValidator = require('./validators/amount')
+const priceValidator = require('./validators/price')
+const symbolValidator = require('./validators/symbol')
 const Model = require('./model')
 const fields = {
   symbol: 0,
@@ -57,6 +61,32 @@ class TradingTicker extends Model {
    */
   base () {
     return (this.symbol || '').substring(1, 4)
+  }
+
+  /**
+   * Validates a given trading ticker instance
+   *
+   * @param {Object[]|Object|PublicTrade[]|PublicTrade|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        symbol: symbolValidator,
+        bid: priceValidator,
+        bidSize: amountValidator,
+        ask: priceValidator,
+        askSize: amountValidator,
+        dailyChange: numberValidator,
+        dailyChangePerc: numberValidator,
+        lastPrice: priceValidator,
+        volume: numberValidator,
+        high: priceValidator,
+        low: priceValidator
+      }
+    })
   }
 }
 

--- a/lib/trading_ticker.js
+++ b/lib/trading_ticker.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   symbol: 0,
   bid: 1,
   bidSize: 2,
@@ -15,8 +14,6 @@ const FIELDS = {
   high: 9,
   low: 10
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Trading Ticker model
@@ -37,29 +34,29 @@ class TradingTicker extends Model {
    * @param {number} data.low
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 
   /**
    * @return {string} quoteCurrency
    */
   quote () {
-    return this.symbol.substring(4)
+    return (this.symbol || '').substring(4)
   }
 
   /**
    * @return {string} baseCurrency
    */
   base () {
-    return this.symbol.substring(1, 4)
+    return (this.symbol || '').substring(1, 4)
   }
 }
 

--- a/lib/trading_ticker_hist.js
+++ b/lib/trading_ticker_hist.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const symbolValidator = require('./validators/symbol')
+const priceValidator = require('./validators/price')
+const dateValidator = require('./validators/date')
 const Model = require('./model')
 const fields = {
   symbol: 0,
@@ -43,6 +46,25 @@ class TradingTickerHist extends Model {
    */
   base () {
     return (this.symbol || '').substring(1, 4)
+  }
+
+  /**
+   * Validates a given historical trading ticker instance
+   *
+   * @param {Object[]|Object|TradingTickerHist[]|TradingTickerHist|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        symbol: symbolValidator,
+        bid: priceValidator,
+        ask: priceValidator,
+        mtsUpdated: dateValidator
+      }
+    })
   }
 }
 

--- a/lib/trading_ticker_hist.js
+++ b/lib/trading_ticker_hist.js
@@ -1,15 +1,12 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   symbol: 0,
   bid: 1,
   ask: 3,
   mtsUpdate: 12
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Historical Trading Ticker model
@@ -23,29 +20,29 @@ class TradingTickerHist extends Model {
    * @param {number} data.mtsUpdate
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 
   /**
    * @return {string} quoteCurrency
    */
   quote () {
-    return this.symbol.substring(4)
+    return (this.symbol || '').substring(4)
   }
 
   /**
    * @return {string} baseCurrency
    */
   base () {
-    return this.symbol.substring(1, 4)
+    return (this.symbol || '').substring(1, 4)
   }
 }
 

--- a/lib/user_info.js
+++ b/lib/user_info.js
@@ -1,15 +1,12 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+const fields = {
   id: 0,
   email: 1,
   username: 2,
   timezone: 7
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * User Info model
@@ -23,15 +20,15 @@ class UserInfo extends Model {
    * @param {number} data.timezone
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 

--- a/lib/user_info.js
+++ b/lib/user_info.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const numberValidator = require('./validators/number')
+const stringValidator = require('./validators/string')
 const Model = require('./model')
 const fields = {
   id: 0,
@@ -29,6 +31,25 @@ class UserInfo extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+   * Validates a given historical trading ticker instance
+   *
+   * @param {Object[]|Object|TradingTickerHist[]|TradingTickerHist|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+      validators: {
+        id: numberValidator,
+        email: stringValidator,
+        username: stringValidator,
+        timezone: stringValidator
+      }
+    })
   }
 }
 

--- a/lib/util/assign_from_collection_or_instance.js
+++ b/lib/util/assign_from_collection_or_instance.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const _isArray = require('lodash/isArray')
+const _isObject = require('lodash/isObject')
+
+/**
+ * Merges provided data onto the target model class, supporting both normal
+ * object/array format packets and arrays of them. If given an array of
+ * packets, the destination model will become iterable.
+ *
+ * @param {Object} args
+ * @param {Object[]|Object|Array[]|Array} args.data
+ * @param {Object?} args.fields - index map in the form { [fieldName]: index }
+ * @param {Array?} args.boolFields - array of boolean field names
+ * @param {ModelClass} args.target
+ */
+const assignFromCollectionOrInstance = ({ data, fields, boolFields, target }) => {
+  // Use/assign passed in data
+  if (!_isArray(data) && _isObject(data)) {
+    Object.assign(target, data)
+  } else if (_isArray(data) && data.length > 0) {
+    // Initialize iterator/setup array-like access if passed an array of model
+    // data.
+    if (_isArray(data[0]) || _isObject(data[0])) {
+      const collection = target.constructor.unserialize(data)
+      target._collection = collection
+
+      Object.assign(target, collection) // needed for [] access
+      target.length = collection.length
+
+      target[Symbol.iterator] = function () {
+        return {
+          _i: -1,
+          next: function () {
+            this._i++
+
+            return this._i === collection.length
+              ? { done: true }
+              : { value: collection[this._i], done: false }
+          }
+        }
+      }
+    } else {
+      Object.assign(target, target.constructor.unserialize(data))
+    }
+  }
+}
+
+module.exports = assignFromCollectionOrInstance

--- a/lib/util/assign_from_collection_or_instance.js
+++ b/lib/util/assign_from_collection_or_instance.js
@@ -19,10 +19,16 @@ const assignFromCollectionOrInstance = ({ data, fields, boolFields, target }) =>
   if (!_isArray(data) && _isObject(data)) {
     Object.assign(target, data)
   } else if (_isArray(data) && data.length > 0) {
-    // Initialize iterator/setup array-like access if passed an array of model
-    // data.
-    if (_isArray(data[0]) || _isObject(data[0])) {
-      const collection = target.constructor.unserialize(data)
+    // Initialize iterator/setup array-like access if passed an array of models
+    let toParse = data
+
+    // Don't make an iterable collection if given an array of 1 item
+    if (_isArray(data[0]) && data.length === 1) {
+      toParse = data[0]
+    }
+
+    if (_isArray(toParse[0]) || _isObject(toParse[0])) {
+      const collection = target.constructor.unserialize(toParse)
       target._collection = collection
 
       Object.assign(target, collection) // needed for [] access
@@ -41,7 +47,7 @@ const assignFromCollectionOrInstance = ({ data, fields, boolFields, target }) =>
         }
       }
     } else {
-      Object.assign(target, target.constructor.unserialize(data))
+      Object.assign(target, target.constructor.unserialize(toParse))
     }
   }
 }

--- a/lib/util/is_collection.js
+++ b/lib/util/is_collection.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const _isArray = require('lodash/isArray')
+const _isObject = require('lodash/isObject')
+
+/**
+ * Checks if the provided data is a collection of models
+ *
+ * @param {Object[]|Object|Array[]|Array] data
+ * @return {boolean} isCollection
+ */
+module.exports = (data) => (
+  _isArray(data) && (_isArray(data[0]) || _isObject(data[0]))
+)

--- a/lib/validators/amount.js
+++ b/lib/validators/amount.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const numberValidator = require('./number')
+
+/**
+  * Validates an amount
+  *
+  * @param {*} v
+  * @return {string} error - null if valid
+  */
+module.exports = (v) => numberValidator(v)

--- a/lib/validators/bool.js
+++ b/lib/validators/bool.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const _isBoolean = require('lodash/isBoolean')
+
+/**
+  * Validates a bool
+  *
+  * @param {*} v
+  * @return {string} error - null if valid
+  */
+module.exports = (v) => (!_isBoolean(v)
+  ? 'must be a bool'
+  : null
+)

--- a/lib/validators/currency.js
+++ b/lib/validators/currency.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const _includes = require('lodash/includes')
+const { CURRENCIES } = require('bfx-hf-util')
+const VALID_CURRENCIES = Object.values(CURRENCIES)
+
+/**
+  * Validates a currency
+  *
+  * @param {*} v
+  * @return {string} error - null if valid
+  */
+module.exports = (v) => (!_includes(VALID_CURRENCIES, v)
+  ? 'must be a currency currently tradable on Bitfinex'
+  : null
+)

--- a/lib/validators/date.js
+++ b/lib/validators/date.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const _isFinite = require('lodash/isFinite')
+
+/**
+  * Validates a date
+  *
+  * @param {*} v
+  * @return {string} error - null if valid
+  */
+module.exports = (v) => (!_isFinite(+v) || +v < 0
+  ? 'must be a date or positive number'
+  : null
+)

--- a/lib/validators/number.js
+++ b/lib/validators/number.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const _isFinite = require('lodash/isFinite')
+
+/**
+  * Validates a number
+  *
+  * @param {*} v
+  * @return {string} error - null if valid
+  */
+module.exports = (v) => (!_isFinite(v)
+  ? 'must be a number'
+  : null
+)

--- a/lib/validators/price.js
+++ b/lib/validators/price.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const numberValidator = require('./number')
+
+/**
+  * Validates a price
+  *
+  * @param {*} v
+  * @return {string} error - null if valid
+  */
+module.exports = (v) => (numberValidator(v) || v < 0
+  ? 'must be a number greater than zero'
+  : null
+)

--- a/lib/validators/string.js
+++ b/lib/validators/string.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const _includes = require('lodash/includes')
+const _isString = require('lodash/isString')
+
+/**
+  * Validates a string
+  *
+  * @param {*} v
+  * @param {string[]} validOptions - optional
+  * @return {string} error - null if valid
+  */
+module.exports = (v, validOptions) => (
+  !_isString(v) || (validOptions && !_includes(validOptions, v))
+    ? 'must be a string'
+    : null
+)

--- a/lib/validators/symbol.js
+++ b/lib/validators/symbol.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const _includes = require('lodash/includes')
+const { SYMBOLS } = require('bfx-hf-util')
+const VALID_SYMBOLS = Object.values(SYMBOLS)
+
+/**
+  * Validates a symbol
+  *
+  * @param {*} v
+  * @return {string} error - null if valid
+  */
+module.exports = (v) => (!_includes(VALID_SYMBOLS, v)
+  ? 'must be a symbol currently traded on Bitfinex'
+  : null
+)

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -1,15 +1,12 @@
 'use strict'
 
-const _isObject = require('lodash/isObject')
-const _isString = require('lodash/isString')
-const _isFinite = require('lodash/isFinite')
-const _isEmpty = require('lodash/isEmpty')
-const _includes = require('lodash/includes')
-const { CURRENCIES } = require('bfx-hf-util')
+const amountValidator = require('./validators/amount')
+const currencyValidator = require('./validators/currency')
+const stringValidator = require('./validators/string')
+const { WALLET_TYPES } = require('bfx-hf-util')
 const Model = require('./model')
 
-const VALID_TYPES = ['exchange', 'margin', 'funding']
-const VALID_CURRENCIES = Object.values(CURRENCIES)
+const VALID_TYPES = Object.values(WALLET_TYPES)
 const fields = {
   type: 0,
   currency: 1,
@@ -48,7 +45,7 @@ class Wallet extends Model {
    * Validates a given wallet instance
    *
    * @param {Object[]|Object|Wallet[]|Wallet|Array} data - instance to validate
-   * @return {boolean} valid
+   * @return {string} error - null if instance is valid
    */
   static validate (data) {
     return super.validate({
@@ -56,39 +53,15 @@ class Wallet extends Model {
       fields,
 
       validators: {
-        type: v => (
-          !_includes(VALID_TYPES, v)
-            ? `must be one of ${VALID_TYPES.join(', ')}`
-            : null
-        ),
-
-        currency: v => (
-          !_includes(VALID_CURRENCIES, v)
-            ? 'must be a currency currently tradable on Bitfinex'
-            : null
-        ),
-
-        balance: v => (!_isFinite(v) ? 'must be a number' : null),
-        unsettledInterest: v => (!_isFinite(v) ? 'must be a number' : null),
-        balanceAvailable: v => (!_isFinite(v) ? 'must be a number' : null),
-
-        description: v => (
-          (v !== null && (!_isString(v) || _isEmpty(v)))
-            ? 'can be null or a non-empty string'
-            : null
-        ),
-
-        meta: v => (
-          (v !== null && (!_isObject(v) || _isEmpty(v)))
-            ? 'can be null or a non-empty object'
-            : null
-        )
+        type: v => stringValidator(v, VALID_TYPES),
+        currency: currencyValidator,
+        balance: amountValidator,
+        unsettledInterest: amountValidator,
+        balanceAvailable: amountValidator,
+        description: stringValidator
       }
     })
   }
 }
-
-Wallet.type = {}
-VALID_TYPES.forEach(t => (Wallet.type[t.toUpperCase()] = t))
 
 module.exports = Wallet

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -1,16 +1,24 @@
 'use strict'
 
+const _isObject = require('lodash/isObject')
+const _isString = require('lodash/isString')
+const _isFinite = require('lodash/isFinite')
+const _isEmpty = require('lodash/isEmpty')
+const _includes = require('lodash/includes')
+const { CURRENCIES: CURRENCY_MAP } = require('bfx-hf-util')
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+
+const VALID_TYPES = ['exchange', 'margin', 'funding']
+const VALID_CURRENCIES = Object.values(CURRENCY_MAP)
+const fields = {
   type: 0,
   currency: 1,
   balance: 2,
   unsettledInterest: 3,
-  balanceAvailable: 4
+  balanceAvailable: 4,
+  description: 5,
+  meta: 6
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Wallet model
@@ -25,23 +33,62 @@ class Wallet extends Model {
    * @param {number} data.balanceAvailable
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
+  }
+
+  /**
+   * Validates a given wallet instance
+   *
+   * @param {Object[]|Object|Wallet[]|Wallet|Array} data - instance to validate
+   * @return {boolean} valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+
+      validators: {
+        type: v => (
+          !_includes(VALID_TYPES, v)
+            ? `must be one of ${VALID_TYPES.join(', ')}`
+            : null
+        ),
+
+        currency: v => (
+          !_includes(VALID_CURRENCIES, v)
+            ? 'must be a currency currently tradable on Bitfinex'
+            : null
+        ),
+
+        balance: v => (!_isFinite(v) ? 'must be a number' : null),
+        unsettledInterest: v => (!_isFinite(v) ? 'must be a number' : null),
+        balanceAvailable: v => (!_isFinite(v) ? 'must be a number' : null),
+
+        description: v => (
+          (v !== null && (!_isString(v) || _isEmpty(v)))
+            ? 'can be null or a non-empty string'
+            : null
+        ),
+
+        meta: v => (
+          (v !== null && (!_isObject(v) || _isEmpty(v)))
+            ? 'can be null or a non-empty object'
+            : null
+        )
+      }
+    })
   }
 }
 
 Wallet.type = {}
-const types = ['exchange', 'margin', 'funding']
-
-types.forEach((t) => {
-  Wallet.type[t.toUpperCase()] = t
-})
+VALID_TYPES.forEach(t => (Wallet.type[t.toUpperCase()] = t))
 
 module.exports = Wallet

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -5,11 +5,11 @@ const _isString = require('lodash/isString')
 const _isFinite = require('lodash/isFinite')
 const _isEmpty = require('lodash/isEmpty')
 const _includes = require('lodash/includes')
-const { CURRENCIES: CURRENCY_MAP } = require('bfx-hf-util')
+const { CURRENCIES } = require('bfx-hf-util')
 const Model = require('./model')
 
 const VALID_TYPES = ['exchange', 'margin', 'funding']
-const VALID_CURRENCIES = Object.values(CURRENCY_MAP)
+const VALID_CURRENCIES = Object.values(CURRENCIES)
 const fields = {
   type: 0,
   currency: 1,

--- a/lib/wallet_hist.js
+++ b/lib/wallet_hist.js
@@ -1,8 +1,13 @@
 'use strict'
 
+const amountValidator = require('./validators/amount')
+const currencyValidator = require('./validators/currency')
+const stringValidator = require('./validators/string')
+const dateValidator = require('./validators/date')
+const { WALLET_TYPES } = require('bfx-hf-util')
 const Model = require('./model')
 
-const types = ['exchange', 'margin', 'funding']
+const types = Object.values(WALLET_TYPES)
 const fields = {
   type: 0,
   currency: 1,
@@ -35,6 +40,28 @@ class WalletHist extends Model {
    */
   static unserialize (data) {
     return super.unserialize({ data, fields })
+  }
+
+  /**
+   * Validates a given historical wallet instance
+   *
+   * @param {Object[]|Object|WalletHist[]|WalletHist|Array} data - instance to validate
+   * @return {string} error - null if instance is valid
+   */
+  static validate (data) {
+    return super.validate({
+      data,
+      fields,
+
+      validators: {
+        type: v => stringValidator(v, types),
+        currency: currencyValidator,
+        balance: amountValidator,
+        unsettledInterest: amountValidator,
+        balanceAvailable: amountValidator,
+        mtsUpdate: dateValidator
+      }
+    })
   }
 }
 

--- a/lib/wallet_hist.js
+++ b/lib/wallet_hist.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const Model = require('./model')
-const BOOL_FIELDS = []
-const FIELDS = {
+
+const types = ['exchange', 'margin', 'funding']
+const fields = {
   type: 0,
   currency: 1,
   balance: 2,
@@ -10,8 +11,6 @@ const FIELDS = {
   balanceAvailable: 4,
   mtsUpdate: 6
 }
-
-const FIELD_KEYS = Object.keys(FIELDS)
 
 /**
  * Historical Wallet Update model
@@ -27,23 +26,20 @@ class WalletHist extends Model {
    * @param {number} data.mtsUpdate
    */
   constructor (data = {}) {
-    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+    super({ data, fields })
   }
 
   /**
-   * @param {Object|Array} arr
+   * @param {Object[]Object|Array[]|Array} data
    * @return {Object} pojo
    */
-  static unserialize (arr) {
-    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  static unserialize (data) {
+    return super.unserialize({ data, fields })
   }
 }
 
 WalletHist.type = {}
-const types = ['exchange', 'margin', 'funding']
 
-types.forEach((t) => {
-  WalletHist.type[t.toUpperCase()] = t
-})
+types.forEach(t => (WalletHist.type[t.toUpperCase()] = t))
 
 module.exports = WalletHist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=7"
@@ -38,6 +38,7 @@
   "devDependencies": {
     "babel-eslint": "^10.0.3",
     "bfx-api-node-rest": "git+http://github.com/bitfinexcom/bfx-api-node-rest.git#semver:^1.1.3",
+    "bfx-hf-util": "^1.0.5",
     "chai": "^4.2.0",
     "jsdoc-to-markdown": "^5.0.1",
     "mocha": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-regenerator": "^6.26.0",
     "bfx-api-node-rest": "^3.0.3",
-    "bfx-hf-util": "^1.0.5",
+    "bfx-hf-util": "^1.0.6",
     "chai": "^4.2.0",
     "husky": "^4.2.3",
     "jsdoc-to-markdown": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "lint": "standard",
     "test": "npm run lint && npm run unit",
-    "unit": "NODE_ENV=test mocha -b --recursive",
-    "build": "babel -q ./index.js -d ./dist && babel -q ./lib -d ./dist/lib && copy package.json dist",
+    "unit": "NODE_ENV=test nyc --check-coverage --lines 90 --branches 60 --functions 90 --statements 90 --reporter=lcov --reporter=html mocha -b --recursive",
+    "build": "babel ./index.js -d ./dist && babel ./lib -d ./dist/lib && copy package.json dist",
     "docs": "npm run model_docs",
     "model_docs": "node_modules/jsdoc-to-markdown/bin/cli.js lib/*.js > docs/model_docs.md"
   },
@@ -36,17 +36,21 @@
   },
   "homepage": "http://bitfinexcom.github.io/bfx-api-node-models/",
   "devDependencies": {
-    "babel-eslint": "^10.0.3",
-    "bfx-api-node-rest": "git+http://github.com/bitfinexcom/bfx-api-node-rest.git#semver:^1.1.3",
+    "babel-cli": "^6.26.0",
+    "babel-eslint": "^10.1.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-regenerator": "^6.26.0",
+    "bfx-api-node-rest": "^3.0.3",
     "bfx-hf-util": "^1.0.5",
     "chai": "^4.2.0",
-    "jsdoc-to-markdown": "^5.0.1",
-    "mocha": "^6.2.0",
+    "jsdoc-to-markdown": "^5.0.3",
+    "mocha": "^7.1.0",
+    "nyc": "^15.0.0",
     "standard": "^14.1.0"
   },
   "dependencies": {
-    "bfx-api-node-util": "^1.0.2",
-    "bluebird": "^3.5.5",
+    "bfx-api-node-util": "^1.0.8",
+    "bluebird": "^3.7.2",
     "crc-32": "^1.2.0",
     "debug": "^4.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
     "node": ">=7"
   },
   "main": "index.js",
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm test"
+    }
+  },
   "scripts": {
     "lint": "standard",
     "test": "npm run lint && npm run unit",
@@ -43,6 +48,7 @@
     "bfx-api-node-rest": "^3.0.3",
     "bfx-hf-util": "^1.0.5",
     "chai": "^4.2.0",
+    "husky": "^4.2.3",
     "jsdoc-to-markdown": "^5.0.3",
     "mocha": "^7.1.0",
     "nyc": "^15.0.0",

--- a/test/helpers/test_model_validation.js
+++ b/test/helpers/test_model_validation.js
@@ -2,6 +2,8 @@
 'use strict'
 
 const assert = require('assert')
+const _min = require('lodash/min')
+const _sample = require('lodash/sample')
 const _isArray = require('lodash/isArray')
 const _isFunction = require('lodash/isFunction')
 const _flattenDeep = require('lodash/flattenDeep')
@@ -11,49 +13,62 @@ const _flattenDeep = require('lodash/flattenDeep')
  *
  * @param {Object} args
  * @param {Object} args.model - class
- * @param {Object[]|Object} args.valid - single or multiple valid instances
- * @param {Object[]|Object} args.invalid - single or multiple invalid instances
+ * @param {Object} args.validData - map of arrays for each key containing valid values
  */
-module.exports = ({ model, valid, invalid }) => {
+module.exports = ({ model, validData }) => {
   it('validate: is provided', () => {
     _isFunction(model.validate)
   })
 
-  if (invalid) {
-    it('validate: false for invalid instance(s)', () => {
-      if (_isArray(invalid)) {
-        assert(model.validate(invalid) instanceof Error) // test all
+  // Generate valid/invalid param sets for fuzzing
+  const valid = []
+  const invalid = []
+  const minDatasetLength = _min(Object.values(validData).map(arr => arr.length))
 
-        invalid.forEach(i => { // test single & array of one
-          assert(model.validate(i) instanceof Error)
-          assert(model.validate([i]) instanceof Error)
-        })
-      } else { // test single & array of one
-        assert(model.validate(invalid) instanceof Error)
-        assert(model.validate([invalid]) instanceof Error)
-      }
+  for (let i = 0; i < minDatasetLength; i += 1) {
+    const validParamSet = {}
+    const invalidParamSet = {}
+
+    Object.keys(validData).forEach((key) => {
+      const v = _sample(validData[key])
+
+      validParamSet[key] = v
+      invalidParamSet[key] = `__not_valid_${v}`
     })
+
+    valid.push(validParamSet)
+    invalid.push(invalidParamSet)
   }
 
-  if (valid) {
-    it('validate: true for valid instance(s)', () => {
-      if (_isArray(valid)) {
-        assert.strictEqual(model.validate(valid), null) // test all
+  it('validate: false for invalid instance(s)', () => {
+    if (_isArray(invalid)) {
+      assert(model.validate(invalid) instanceof Error) // test all
 
-        valid.forEach(i => { // test single & array of one
-          assert.strictEqual(model.validate(i), null)
-          assert.strictEqual(model.validate([i]), null)
-        })
-      } else { // test single & array of one
-        assert.strictEqual(model.validate(valid), null)
-        assert.strictEqual(model.validate([valid]), null)
-      }
-    })
-  }
+      invalid.forEach(i => { // test single & array of one
+        assert(model.validate(i) instanceof Error)
+        assert(model.validate([i]) instanceof Error)
+      })
+    } else { // test single & array of one
+      assert(model.validate(invalid) instanceof Error)
+      assert(model.validate([invalid]) instanceof Error)
+    }
+  })
 
-  if (valid && invalid) {
-    it('validate: false if one instance out of a set is invalid', () => {
-      assert(model.validate(_flattenDeep([valid, invalid])) instanceof Error)
-    })
-  }
+  it('validate: true for valid instance(s)', () => {
+    if (_isArray(valid)) {
+      assert.strictEqual(model.validate(valid), null) // test all
+
+      valid.forEach(i => { // test single & array of one
+        assert.strictEqual(model.validate(i), null)
+        assert.strictEqual(model.validate([i]), null)
+      })
+    } else { // test single & array of one
+      assert.strictEqual(model.validate(valid), null)
+      assert.strictEqual(model.validate([valid]), null)
+    }
+  })
+
+  it('validate: false if one instance out of a set is invalid', () => {
+    assert(model.validate(_flattenDeep([valid, invalid])) instanceof Error)
+  })
 }

--- a/test/helpers/test_model_validation.js
+++ b/test/helpers/test_model_validation.js
@@ -38,15 +38,15 @@ module.exports = ({ model, valid, invalid }) => {
   if (valid) {
     it('validate: true for valid instance(s)', () => {
       if (_isArray(valid)) {
-        assert(model.validate(valid) === null) // test all
+        assert.strictEqual(model.validate(valid), null) // test all
 
         valid.forEach(i => { // test single & array of one
-          assert(model.validate(i) === null)
-          assert(model.validate([i] === null))
+          assert.strictEqual(model.validate(i), null)
+          assert.strictEqual(model.validate([i]), null)
         })
       } else { // test single & array of one
-        assert(model.validate(valid) === null)
-        assert(model.validate([valid]) === null)
+        assert.strictEqual(model.validate(valid), null)
+        assert.strictEqual(model.validate([valid]), null)
       }
     })
   }

--- a/test/helpers/test_model_validation.js
+++ b/test/helpers/test_model_validation.js
@@ -1,0 +1,59 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const _isArray = require('lodash/isArray')
+const _isFunction = require('lodash/isFunction')
+const _flattenDeep = require('lodash/flattenDeep')
+
+/**
+ * Runs basic checks on a model's validate method
+ *
+ * @param {Object} args
+ * @param {Object} args.model - class
+ * @param {Object[]|Object} args.valid - single or multiple valid instances
+ * @param {Object[]|Object} args.invalid - single or multiple invalid instances
+ */
+module.exports = ({ model, valid, invalid }) => {
+  it('validate: is provided', () => {
+    _isFunction(model.validate)
+  })
+
+  if (invalid) {
+    it('validate: false for invalid instance(s)', () => {
+      if (_isArray(invalid)) {
+        assert(model.validate(invalid) instanceof Error) // test all
+
+        invalid.forEach(i => { // test single & array of one
+          assert(model.validate(i) instanceof Error)
+          assert(model.validate([i]) instanceof Error)
+        })
+      } else { // test single & array of one
+        assert(model.validate(invalid) instanceof Error)
+        assert(model.validate([invalid]) instanceof Error)
+      }
+    })
+  }
+
+  if (valid) {
+    it('validate: true for valid instance(s)', () => {
+      if (_isArray(valid)) {
+        assert(model.validate(valid) === null) // test all
+
+        valid.forEach(i => { // test single & array of one
+          assert(model.validate(i) === null)
+          assert(model.validate([i] === null))
+        })
+      } else { // test single & array of one
+        assert(model.validate(valid) === null)
+        assert(model.validate([valid]) === null)
+      }
+    })
+  }
+
+  if (valid && invalid) {
+    it('validate: false if one instance out of a set is invalid', () => {
+      assert(model.validate(_flattenDeep([valid, invalid])) instanceof Error)
+    })
+  }
+}

--- a/test/lib/models/alert.js
+++ b/test/lib/models/alert.js
@@ -1,12 +1,22 @@
 /* eslint-env mocha */
 'use strict'
 
+const { SYMBOLS } = require('bfx-hf-util')
 const { Alert } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
 
 describe('Alert model', () => {
   testModel({
     model: Alert,
     orderedFields: ['key', 'type', 'symbol', 'price']
+  })
+
+  testModelValidation({
+    model: Alert,
+    validData: {
+      symbol: Object.values(SYMBOLS),
+      price: new Array(...(new Array(5))).map(() => Math.random())
+    }
   })
 })

--- a/test/lib/models/balance_info.js
+++ b/test/lib/models/balance_info.js
@@ -3,10 +3,19 @@
 
 const { BalanceInfo } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
 
 describe('BalanceInfo model', () => {
   testModel({
     model: BalanceInfo,
     orderedFields: ['amount', 'amountNet']
+  })
+
+  testModelValidation({
+    model: BalanceInfo,
+    validData: {
+      amount: new Array(...(new Array(5))).map(() => Math.random()),
+      amountNet: new Array(...(new Array(5))).map(() => Math.random())
+    }
   })
 })

--- a/test/lib/models/candle.js
+++ b/test/lib/models/candle.js
@@ -5,11 +5,24 @@ const assert = require('assert')
 const { RESTv2 } = require('bfx-api-node-rest')
 const { Candle } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
 
 describe('Candle model', () => {
   testModel({
     model: Candle,
     orderedFields: ['mts', 'open', 'close', 'high', 'low', 'volume']
+  })
+
+  testModelValidation({
+    model: Candle,
+    validData: {
+      mts: new Array(...(new Array(5))).map(() => Math.random()),
+      open: new Array(...(new Array(5))).map(() => Math.random()),
+      high: new Array(...(new Array(5))).map(() => Math.random()),
+      low: new Array(...(new Array(5))).map(() => Math.random()),
+      close: new Array(...(new Array(5))).map(() => Math.random()),
+      volume: new Array(...(new Array(5))).map(() => Math.random())
+    }
   })
 
   it('unserializes live data correctly', async () => {

--- a/test/lib/models/currency.js
+++ b/test/lib/models/currency.js
@@ -1,0 +1,12 @@
+/* eslint-env mocha */
+'use strict'
+
+const { Currency } = require('../../../lib')
+const testModel = require('../../helpers/test_model')
+
+describe('Currency model', () => {
+  testModel({
+    model: Currency,
+    orderedFields: ['id', 'name', 'pool', 'explorer', 'symbol']
+  })
+})

--- a/test/lib/models/currency.js
+++ b/test/lib/models/currency.js
@@ -1,12 +1,28 @@
 /* eslint-env mocha */
 'use strict'
 
+const { WALLET_TYPES, CURRENCIES } = require('bfx-hf-util')
 const { Currency } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+// get data from somewhere
+const VALID_STRINGS = Object.values(WALLET_TYPES)
 
 describe('Currency model', () => {
   testModel({
     model: Currency,
     orderedFields: ['id', 'name', 'pool', 'explorer', 'symbol']
+  })
+
+  testModelValidation({
+    model: Currency,
+    validData: {
+      currency: Object.values(CURRENCIES),
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      name: VALID_STRINGS,
+      pool: VALID_STRINGS,
+      explorer: VALID_STRINGS
+    }
   })
 })

--- a/test/lib/models/funding_credit.js
+++ b/test/lib/models/funding_credit.js
@@ -1,8 +1,12 @@
 /* eslint-env mocha */
 'use strict'
 
+const { SYMBOLS } = require('bfx-hf-util')
 const { FundingCredit } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 
 describe('FundingCredit model', () => {
   testModel({
@@ -14,5 +18,27 @@ describe('FundingCredit model', () => {
       'mtsLastPayout', 'notify', 'hidden', null, 'renew', 'rateReal', 'noClose',
       'positionPair'
     ]
+  })
+
+  testModelValidation({
+    model: FundingCredit,
+    validData: {
+      symbol: VALID_SYMBOLS,
+      status: VALID_SYMBOLS, // need data from somewhere
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsCreate: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsUpdate: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsOpening: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsLastPayout: new Array(...(new Array(5))).map(() => Math.random()),
+      amount: new Array(...(new Array(5))).map(() => Math.random()),
+      flags: new Array(...(new Array(5))).map(() => Math.random()),
+      rate: new Array(...(new Array(5))).map(() => Math.random()),
+      period: new Array(...(new Array(5))).map(() => Math.random()),
+      rateReal: new Array(...(new Array(5))).map(() => Math.random()),
+      notify: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      hidden: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      renew: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      noClose: new Array(...(new Array(5))).map(() => Math.random() > 0.5)
+    }
   })
 })

--- a/test/lib/models/funding_info.js
+++ b/test/lib/models/funding_info.js
@@ -5,6 +5,8 @@ const assert = require('assert')
 const { FundingInfo } = require('../../../lib')
 
 describe('FundingInfo model', () => {
+  // TODO: test validation
+
   it('initializes correctly', () => {
     const fi = new FundingInfo([
       'sym',

--- a/test/lib/models/funding_loan.js
+++ b/test/lib/models/funding_loan.js
@@ -1,8 +1,12 @@
 /* eslint-env mocha */
 'use strict'
 
+const { SYMBOLS } = require('bfx-hf-util')
 const { FundingLoan } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 
 describe('FundingLoan model', () => {
   testModel({
@@ -13,5 +17,27 @@ describe('FundingLoan model', () => {
       'status', null, null, null, 'rate', 'period', 'mtsOpening',
       'mtsLastPayout', 'notify', 'hidden', null, 'renew', 'rateReal', 'noClose'
     ]
+  })
+
+  testModelValidation({
+    model: FundingLoan,
+    validData: {
+      symbol: VALID_SYMBOLS,
+      status: VALID_SYMBOLS, // need data from somewhere
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsCreate: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsUpdate: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsOpening: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsLastPayout: new Array(...(new Array(5))).map(() => Math.random()),
+      amount: new Array(...(new Array(5))).map(() => Math.random()),
+      flags: new Array(...(new Array(5))).map(() => Math.random()),
+      rate: new Array(...(new Array(5))).map(() => Math.random()),
+      period: new Array(...(new Array(5))).map(() => Math.random()),
+      rateReal: new Array(...(new Array(5))).map(() => Math.random()),
+      notify: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      hidden: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      renew: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      noClose: new Array(...(new Array(5))).map(() => Math.random() > 0.5)
+    }
   })
 })

--- a/test/lib/models/funding_offer.js
+++ b/test/lib/models/funding_offer.js
@@ -1,6 +1,9 @@
 /* eslint-env mocha */
 'use strict'
 
+const assert = require('assert')
+const { prepareAmount } = require('bfx-api-node-util')
+const { RESTv2 } = require('bfx-api-node-rest')
 const { FundingOffer } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
 
@@ -13,5 +16,128 @@ describe('FundingOffer model', () => {
       null, null, 'flags', 'status', null, null, null, 'rate', 'period',
       'notify', 'hidden', null, 'renew', 'rateReal'
     ]
+  })
+
+  describe('toNewOfferPacket', () => {
+    it('generates a valid packet for WSv2', () => {
+      const data = {
+        type: 'test',
+        symbol: 'fUSD',
+        amount: prepareAmount(42),
+        rate: prepareAmount(0.1),
+        period: '30',
+        flags: 0
+      }
+
+      const fo = new FundingOffer(data)
+      assert.deepStrictEqual(fo.toNewOfferPacket(), data)
+    })
+  })
+
+  describe('submit', () => {
+    it('throws an error if no API interface is available', (done) => {
+      const fo = new FundingOffer()
+      fo.submit().catch(() => done())
+    })
+
+    it('calls submitFundingOffer on the RESTv2 instance', (done) => {
+      const fo = new FundingOffer()
+      const rest = new RESTv2()
+
+      rest.submitFundingOffer = async () => {
+        done()
+        return []
+      }
+
+      fo.submit(rest)
+    })
+
+    it('saves received data on itself', async () => {
+      const rest = new RESTv2()
+      const fo = new FundingOffer({ symbol: 'tBTCUSD' })
+      const remoteFO = new FundingOffer({ symbol: 'just-testing' })
+
+      rest.submitFundingOffer = async () => remoteFO.serialize()
+
+      await fo.submit(rest)
+      assert.strictEqual(fo.symbol, 'just-testing')
+    })
+  })
+
+  describe('cancel', () => {
+    it('throws an error if no API interface is available', (done) => {
+      const fo = new FundingOffer()
+      fo.cancel().catch(() => done())
+    })
+
+    it('calls cancelFundingOffer on the RESTv2 instance', (done) => {
+      const fo = new FundingOffer()
+      const rest = new RESTv2()
+
+      rest.cancelFundingOffer = async () => {
+        done()
+        return []
+      }
+
+      fo.cancel(rest)
+    })
+
+    it('saves received data on itself', async () => {
+      const rest = new RESTv2()
+      const fo = new FundingOffer({ symbol: 'tBTCUSD' })
+      const remoteFO = new FundingOffer({ symbol: 'just-testing' })
+
+      rest.cancelFundingOffer = async () => remoteFO.serialize()
+
+      await fo.cancel(rest)
+      assert.strictEqual(fo.symbol, 'just-testing')
+    })
+  })
+
+  describe('close', () => {
+    it('throws an error if no API interface is available', (done) => {
+      const fo = new FundingOffer()
+      fo.close().catch(() => done())
+    })
+
+    it('calls closeFunding on the RESTv2 instance', (done) => {
+      const fo = new FundingOffer()
+      const rest = new RESTv2()
+
+      rest.closeFunding = async () => {
+        done()
+        return []
+      }
+
+      fo.close(rest)
+    })
+
+    it('saves received data on itself', async () => {
+      const rest = new RESTv2()
+      const fo = new FundingOffer({ symbol: 'tBTCUSD' })
+      const remoteFO = new FundingOffer({ symbol: 'just-testing' })
+
+      rest.closeFunding = async () => remoteFO.serialize()
+
+      await fo.close(rest)
+      assert.strictEqual(fo.symbol, 'just-testing')
+    })
+  })
+
+  describe('toString', () => {
+    it('includes pertinent information', () => {
+      const fo = new FundingOffer({
+        symbol: 'tBTCUSD',
+        amount: 42,
+        rate: 0.1,
+        period: 30
+      })
+
+      const str = fo.toString()
+      assert.ok(/BTCUSD/.test(str), 'symbol missing')
+      assert.ok(str.indexOf('42') !== -1, 'amount missing')
+      assert.ok(str.indexOf('0.1') !== -1, 'rate missing')
+      assert.ok(str.indexOf('30') !== -1, 'period missing')
+    })
   })
 })

--- a/test/lib/models/funding_offer.js
+++ b/test/lib/models/funding_offer.js
@@ -2,10 +2,14 @@
 'use strict'
 
 const assert = require('assert')
+const { SYMBOLS } = require('bfx-hf-util')
 const { prepareAmount } = require('bfx-api-node-util')
 const { RESTv2 } = require('bfx-api-node-rest')
 const { FundingOffer } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 
 describe('FundingOffer model', () => {
   testModel({
@@ -16,6 +20,30 @@ describe('FundingOffer model', () => {
       null, null, 'flags', 'status', null, null, null, 'rate', 'period',
       'notify', 'hidden', null, 'renew', 'rateReal'
     ]
+  })
+
+  testModelValidation({
+    model: FundingOffer,
+    validData: {
+      symbol: VALID_SYMBOLS,
+      status: VALID_SYMBOLS, // need data from somewhere
+      type: VALID_SYMBOLS, // need data from somewhere
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsCreate: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsUpdate: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsOpening: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsLastPayout: new Array(...(new Array(5))).map(() => Math.random()),
+      amountOrig: new Array(...(new Array(5))).map(() => Math.random()),
+      amount: new Array(...(new Array(5))).map(() => Math.random()),
+      flags: new Array(...(new Array(5))).map(() => Math.random()),
+      rate: new Array(...(new Array(5))).map(() => Math.random()),
+      period: new Array(...(new Array(5))).map(() => Math.random()),
+      rateReal: new Array(...(new Array(5))).map(() => Math.random()),
+      notify: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      hidden: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      renew: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      noClose: new Array(...(new Array(5))).map(() => Math.random() > 0.5)
+    }
   })
 
   describe('toNewOfferPacket', () => {

--- a/test/lib/models/funding_ticker.js
+++ b/test/lib/models/funding_ticker.js
@@ -86,4 +86,18 @@ describe('FundingTicker model', () => {
     assert.strictEqual(obj.high, arr[12])
     assert.strictEqual(obj.low, arr[13])
   }).timeout(60000)
+
+  describe('quote', () => {
+    it('returns quote currency', () => {
+      const t = new FundingTicker({ symbol: 'tBTCUSD' })
+      assert.strictEqual(t.quote(), 'USD')
+    })
+  })
+
+  describe('base', () => {
+    it('returns base currency', () => {
+      const t = new FundingTicker({ symbol: 'tBTCUSD' })
+      assert.strictEqual(t.base(), 'BTC')
+    })
+  })
 })

--- a/test/lib/models/funding_ticker.js
+++ b/test/lib/models/funding_ticker.js
@@ -2,9 +2,13 @@
 'use strict'
 
 const assert = require('assert')
+const { SYMBOLS } = require('bfx-hf-util')
 const { RESTv2 } = require('bfx-api-node-rest')
 const { FundingTicker } = require('../../../lib')
+const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
 
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 const DATA = [
   'fUSD',
   0.00009351,
@@ -23,6 +27,35 @@ const DATA = [
 ]
 
 describe('FundingTicker model', () => {
+  testModel({
+    model: FundingTicker,
+    orderedFields: [
+      'symbol', 'frr', 'bid', 'bidSize', 'bidPeriod', 'ask', 'askSize',
+      'askPeriod', 'dailyChange', 'dailyChangePerc', 'lastPrice', 'volume',
+      'high', 'low'
+    ]
+  })
+
+  testModelValidation({
+    model: FundingTicker,
+    validData: {
+      symbol: VALID_SYMBOLS,
+      bid: new Array(...(new Array(5))).map(() => Math.random()),
+      bidSize: new Array(...(new Array(5))).map(() => Math.random()),
+      bidPeriod: new Array(...(new Array(5))).map(() => Math.random()),
+      ask: new Array(...(new Array(5))).map(() => Math.random()),
+      askSize: new Array(...(new Array(5))).map(() => Math.random()),
+      askPeriod: new Array(...(new Array(5))).map(() => Math.random()),
+      dailyChange: new Array(...(new Array(5))).map(() => Math.random()),
+      dailyChangePerc: new Array(...(new Array(5))).map(() => Math.random()),
+      lastPrice: new Array(...(new Array(5))).map(() => Math.random()),
+      volume: new Array(...(new Array(5))).map(() => Math.random()),
+      high: new Array(...(new Array(5))).map(() => Math.random()),
+      low: new Array(...(new Array(5))).map(() => Math.random()),
+      frr: new Array(...(new Array(5))).map(() => Math.random() > 0.5)
+    }
+  })
+
   it('initializes correctly', () => {
     const ticker = new FundingTicker(DATA)
     assert.strictEqual(ticker.symbol, 'fUSD')

--- a/test/lib/models/funding_ticker_hist.js
+++ b/test/lib/models/funding_ticker_hist.js
@@ -2,9 +2,13 @@
 'use strict'
 
 const assert = require('assert')
+const { SYMBOLS } = require('bfx-hf-util')
 const { RESTv2 } = require('bfx-api-node-rest')
 const { FundingTickerHist } = require('../../../lib')
+const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
 
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 const DATA = [
   'fUSD',
   null,
@@ -25,6 +29,25 @@ const DATA = [
 ]
 
 describe('FundingTicker history model', () => {
+  testModel({
+    model: FundingTickerHist,
+    orderedFields: [
+      'symbol', null, 'bid', null, 'bidPeriod', 'ask', null, null, null, null,
+      null, null, null, null, null, 'mtsUpdate'
+    ]
+  })
+
+  testModelValidation({
+    model: FundingTickerHist,
+    validData: {
+      symbol: VALID_SYMBOLS,
+      bid: new Array(...(new Array(5))).map(() => Math.random()),
+      bidPeriod: new Array(...(new Array(5))).map(() => Math.random()),
+      ask: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsUpdate: new Array(...(new Array(5))).map(() => Math.random())
+    }
+  })
+
   it('initializes correctly', () => {
     const ticker = new FundingTickerHist(DATA)
     assert.strictEqual(ticker.symbol, 'fUSD')

--- a/test/lib/models/funding_ticker_hist.js
+++ b/test/lib/models/funding_ticker_hist.js
@@ -60,4 +60,18 @@ describe('FundingTicker history model', () => {
     assert.strictEqual(obj.ask, arr[5])
     assert.strictEqual(obj.mtsUpdate, arr[15])
   }).timeout(60000)
+
+  describe('quote', () => {
+    it('returns quote currency', () => {
+      const t = new FundingTickerHist({ symbol: 'tBTCUSD' })
+      assert.strictEqual(t.quote(), 'USD')
+    })
+  })
+
+  describe('base', () => {
+    it('returns base currency', () => {
+      const t = new FundingTickerHist({ symbol: 'tBTCUSD' })
+      assert.strictEqual(t.base(), 'BTC')
+    })
+  })
 })

--- a/test/lib/models/funding_trade.js
+++ b/test/lib/models/funding_trade.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const assert = require('assert')
 const { FundingTrade } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
 
@@ -11,5 +12,22 @@ describe('FundingTrade model', () => {
       'id', 'symbol', 'mtsCreate', 'offerID', 'amount', 'rate', 'period',
       'maker'
     ]
+  })
+
+  describe('toString', () => {
+    it('includes pertinent information', () => {
+      const ft = new FundingTrade({
+        symbol: 'tBTCUSD',
+        amount: 42,
+        rate: 0.1,
+        period: 30
+      })
+
+      const str = ft.toString()
+      assert.ok(/BTCUSD/.test(str), 'symbol missing')
+      assert.ok(str.indexOf('42') !== -1, 'amount missing')
+      assert.ok(str.indexOf('0.1') !== -1, 'rate missing')
+      assert.ok(str.indexOf('30') !== -1, 'period missing')
+    })
   })
 })

--- a/test/lib/models/funding_trade.js
+++ b/test/lib/models/funding_trade.js
@@ -2,8 +2,12 @@
 'use strict'
 
 const assert = require('assert')
+const { SYMBOLS } = require('bfx-hf-util')
 const { FundingTrade } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 
 describe('FundingTrade model', () => {
   testModel({
@@ -12,6 +16,20 @@ describe('FundingTrade model', () => {
       'id', 'symbol', 'mtsCreate', 'offerID', 'amount', 'rate', 'period',
       'maker'
     ]
+  })
+
+  testModelValidation({
+    model: FundingTrade,
+    validData: {
+      symbol: VALID_SYMBOLS,
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsCreate: new Array(...(new Array(5))).map(() => Math.random()),
+      offerID: new Array(...(new Array(5))).map(() => Math.random()),
+      amount: new Array(...(new Array(5))).map(() => Math.random()),
+      rate: new Array(...(new Array(5))).map(() => Math.random()),
+      period: new Array(...(new Array(5))).map(() => Math.random()),
+      maker: new Array(...(new Array(5))).map(() => Math.random() > 0.5)
+    }
   })
 
   describe('toString', () => {

--- a/test/lib/models/ledger_entry.js
+++ b/test/lib/models/ledger_entry.js
@@ -1,8 +1,12 @@
 /* eslint-env mocha */
 'use strict'
 
+const { CURRENCIES } = require('bfx-hf-util')
 const { LedgerEntry } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_CURRENCIES = Object.values(CURRENCIES)
 
 describe('Ledger entry model', () => {
   testModel({
@@ -11,5 +15,17 @@ describe('Ledger entry model', () => {
       'id', 'currency', null, 'mts', null, 'amount', 'balance', null,
       'description'
     ]
+  })
+
+  testModelValidation({
+    model: LedgerEntry,
+    validData: {
+      currency: VALID_CURRENCIES,
+      description: VALID_CURRENCIES, // pull data from somewhere
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      mts: new Array(...(new Array(5))).map(() => Math.random()),
+      amount: new Array(...(new Array(5))).map(() => Math.random()),
+      balance: new Array(...(new Array(5))).map(() => Math.random())
+    }
   })
 })

--- a/test/lib/models/liquidations.js
+++ b/test/lib/models/liquidations.js
@@ -2,8 +2,12 @@
 'use strict'
 
 const assert = require('assert')
+const { SYMBOLS } = require('bfx-hf-util')
 const { Liquidations } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 
 describe('Liquidations entry model', () => {
   testModel({
@@ -11,6 +15,19 @@ describe('Liquidations entry model', () => {
     orderedFields: [
       null, 'posId', 'mtsUpdated', null, 'symbol', 'amount', 'basePrice', null, 'isMatch', 'isMarketSold'
     ]
+  })
+
+  testModelValidation({
+    model: Liquidations,
+    validData: {
+      symbol: VALID_SYMBOLS,
+      posId: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsUpdated: new Array(...(new Array(5))).map(() => Math.random()),
+      amount: new Array(...(new Array(5))).map(() => Math.random()),
+      basePrice: new Array(...(new Array(5))).map(() => Math.random()),
+      isMatch: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      isMarketSold: new Array(...(new Array(5))).map(() => Math.random() > 0.5)
+    }
   })
 
   describe('toString', () => {

--- a/test/lib/models/liquidations.js
+++ b/test/lib/models/liquidations.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const assert = require('assert')
 const { Liquidations } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
 
@@ -10,5 +11,20 @@ describe('Liquidations entry model', () => {
     orderedFields: [
       null, 'posId', 'mtsUpdated', null, 'symbol', 'amount', 'basePrice', null, 'isMatch', 'isMarketSold'
     ]
+  })
+
+  describe('toString', () => {
+    it('includes pertinent information', () => {
+      const l = new Liquidations({
+        symbol: 'tBTCUSD',
+        amount: 42,
+        basePrice: 0.1
+      })
+
+      const str = l.toString()
+      assert.ok(/BTCUSD/.test(str), 'symbol missing')
+      assert.ok(str.indexOf('42') !== -1, 'amount missing')
+      assert.ok(str.indexOf('0.1') !== -1, 'rate missing')
+    })
   })
 })

--- a/test/lib/models/login.js
+++ b/test/lib/models/login.js
@@ -1,8 +1,12 @@
 /* eslint-env mocha */
 'use strict'
 
+const { SYMBOLS } = require('bfx-hf-util')
 const { Login } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 
 describe('Login entry model', () => {
   testModel({
@@ -10,5 +14,14 @@ describe('Login entry model', () => {
     orderedFields: [
       'id', null, 'time', null, 'ip', null, null, 'extraData'
     ]
+  })
+
+  testModelValidation({
+    model: Login,
+    validData: {
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      time: new Array(...(new Array(5))).map(() => Math.random()),
+      ip: VALID_SYMBOLS // grab data from somewhere
+    }
   })
 })

--- a/test/lib/models/margin_info.js
+++ b/test/lib/models/margin_info.js
@@ -5,6 +5,8 @@ const assert = require('assert')
 const { MarginInfo } = require('../../../lib')
 
 describe('MarginInfo model', () => {
+  // TODO: test validation
+
   it('initializes correctly w/ sym', () => {
     const miSym = new MarginInfo([
       'sym',

--- a/test/lib/models/model.js
+++ b/test/lib/models/model.js
@@ -1,0 +1,50 @@
+'use strict'
+/* eslint-env mocha */
+
+const assert = require('assert')
+const _isFinite = require('lodash/isFinite')
+const _isString = require('lodash/isString')
+const _isEmpty = require('lodash/isEmpty')
+const Model = require('../../../lib/model')
+
+describe('base model class', () => {
+  describe('validate', () => {
+    const fields = { num: 0, str: 1 }
+    const validators = {
+      num: v => _isFinite(v) ? null : 'must be a number',
+      str: v => (_isString(v) && !_isEmpty(v)) ? null : 'must be a non-empty string'
+    }
+
+    const validateArgs = { fields, validators }
+    const validInstance = { num: 42, str: 'some_data' }
+    const invalidInstance = { num: null, str: null }
+
+    it('returns null if an item passes the provided validators', () => {
+      assert(Model.validate({
+        data: validInstance,
+        ...validateArgs
+      }) === null)
+    })
+
+    it('returns error if an item fails the provided validators', () => {
+      assert(Model.validate({
+        data: invalidInstance,
+        ...validateArgs
+      }) instanceof Error)
+    })
+
+    it('returns error if a single item in a collection fails the validators', () => {
+      assert(Model.validate({
+        data: [validInstance, validInstance, invalidInstance, validInstance],
+        ...validateArgs
+      }) instanceof Error)
+    })
+
+    it('returns null if all items in a collection pass the validators', () => {
+      assert(Model.validate({
+        data: [validInstance, validInstance, validInstance, validInstance],
+        ...validateArgs
+      }) === null)
+    })
+  })
+})

--- a/test/lib/models/model.js
+++ b/test/lib/models/model.js
@@ -9,7 +9,7 @@ const Model = require('../../../lib/model')
 
 describe('base model class', () => {
   describe('toJS', () => {
-    it('returns a pojo version of the model', function() {
+    it('returns a pojo version of the model', function () {
       const fields = { a: 0 }
 
       class SomeModel extends Model {

--- a/test/lib/models/model.js
+++ b/test/lib/models/model.js
@@ -8,6 +8,27 @@ const _isEmpty = require('lodash/isEmpty')
 const Model = require('../../../lib/model')
 
 describe('base model class', () => {
+  describe('toJS', () => {
+    it('returns a pojo version of the model', function() {
+      const fields = { a: 0 }
+
+      class SomeModel extends Model {
+        constructor (data) {
+          super({ data, fields })
+        }
+
+        static unserialize (data) {
+          return super.unserialize({ data, fields })
+        }
+      }
+
+      const m = new SomeModel({ a: 42 })
+      const js = m.toJS()
+
+      assert.deepStrictEqual(js, { a: 42 })
+    })
+  })
+
   describe('validate', () => {
     const fields = { num: 0, str: 1 }
     const validators = {

--- a/test/lib/models/movement.js
+++ b/test/lib/models/movement.js
@@ -1,8 +1,12 @@
 /* eslint-env mocha */
 'use strict'
 
+const { CURRENCIES } = require('bfx-hf-util')
 const { Movement } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_CURRENCIES = Object.values(CURRENCIES)
 
 describe('Movement model', () => {
   testModel({
@@ -12,5 +16,21 @@ describe('Movement model', () => {
       null, null, 'status', null, null, 'amount', 'fees', null, null,
       'destinationAddress', null, null, null, 'transactionId'
     ]
+  })
+
+  testModelValidation({
+    model: Movement,
+    validData: {
+      currency: VALID_CURRENCIES,
+      currencyName: VALID_CURRENCIES, // pull data from somewhere
+      destinationAddress: VALID_CURRENCIES, // pull data from somewhere
+      transactionId: VALID_CURRENCIES, // pull data from somewhere
+      status: VALID_CURRENCIES, // pull data from somewhere
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsStarted: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsUpdated: new Array(...(new Array(5))).map(() => Math.random()),
+      amount: new Array(...(new Array(5))).map(() => Math.random()),
+      fees: new Array(...(new Array(5))).map(() => Math.random())
+    }
   })
 })

--- a/test/lib/models/notification.js
+++ b/test/lib/models/notification.js
@@ -1,8 +1,12 @@
 /* eslint-env mocha */
 'use strict'
 
+const { SYMBOLS } = require('bfx-hf-util')
 const { Notification } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_STRINGS = Object.values(SYMBOLS)
 
 describe('Notification model', () => {
   testModel({
@@ -10,5 +14,17 @@ describe('Notification model', () => {
     orderedFields: [
       'mts', 'type', 'messageID', null, 'notifyInfo', 'code', 'status', 'text'
     ]
+  })
+
+  testModelValidation({
+    model: Notification,
+    validData: {
+      status: VALID_STRINGS, // pull data from somewhere
+      text: VALID_STRINGS, // pull data from somewhere
+      type: ['success', 'error', 'info'],
+      mts: new Array(...(new Array(5))).map(() => Math.random()),
+      messageID: new Array(...(new Array(5))).map(() => Math.random()),
+      code: new Array(...(new Array(5))).map(() => Math.random())
+    }
   })
 })

--- a/test/lib/models/order.js
+++ b/test/lib/models/order.js
@@ -3,8 +3,12 @@
 
 const assert = require('assert')
 const _isFunction = require('lodash/isFunction')
+const { SYMBOLS } = require('bfx-hf-util')
 const { Order } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 
 describe('Order model', () => {
   testModel({
@@ -16,6 +20,32 @@ describe('Order model', () => {
       null, 'price', 'priceAvg', 'priceTrailing', 'priceAuxLimit', null, null,
       null, 'notify', 'hidden', 'placedId', null, null, 'routing', null, null, 'meta'
     ]
+  })
+
+  testModelValidation({
+    model: Order,
+    validData: {
+      symbol: VALID_SYMBOLS,
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      gid: new Array(...(new Array(5))).map(() => Math.random()),
+      cid: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsCreate: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsUpdate: new Array(...(new Array(5))).map(() => Math.random()),
+      amount: new Array(...(new Array(5))).map(() => Math.random()),
+      amountOrig: new Array(...(new Array(5))).map(() => Math.random()),
+      type: Object.values(Order.type),
+      typePrev: Object.values(Order.type),
+      status: Object.values(Order.type), // get some data
+      mtsTIF: new Array(...(new Array(5))).map(() => Math.random()),
+      flags: new Array(...(new Array(5))).map(() => Math.random()),
+      price: new Array(...(new Array(5))).map(() => Math.random()),
+      priceAvg: new Array(...(new Array(5))).map(() => Math.random()),
+      priceTrailing: new Array(...(new Array(5))).map(() => Math.random()),
+      priceAuxLimit: new Array(...(new Array(5))).map(() => Math.random()),
+      notify: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      hidden: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      placedId: new Array(...(new Array(5))).map(() => Math.random())
+    }
   })
 
   it('toNewOrderPacket: uses correct values', () => {

--- a/test/lib/models/order_book.js
+++ b/test/lib/models/order_book.js
@@ -811,4 +811,43 @@ describe('OrderBook model', () => {
       }
     })
   }).timeout(60000)
+
+  describe.skip('volBPSMid', () => {})
+
+  describe('spread', () => {
+    it('returns total spread', () => {
+      const book = new OrderBook({
+        bids: [[1, 0, 1]],
+        asks: [[2, 0, -1]]
+      })
+      assert.strictEqual(book.spread(), 1)
+    })
+  })
+
+  describe('bidAmount', () => {
+    it('returns total bid amount', () => {
+      const book = new OrderBook({
+        bids: [[1, 0, 1], [1.1, 0, 1]],
+        asks: [[2, 0, -1]]
+      })
+      assert.strictEqual(book.bidAmount(), 2)
+    })
+  })
+
+  describe('askAmount', () => {
+    it('returns total ask amount', () => {
+      const book = new OrderBook({
+        bids: [[1, 0, 1]],
+        asks: [[2, 0, -1], [2.1, 0, -1]]
+      })
+      assert.strictEqual(book.askAmount(), 2)
+    })
+  })
+
+  describe('static arrayOBMidPrice', () => {
+    it('returns mid price for an array-format OB', () => {
+      const book = [[2, 0, -1], [1, 0, 1]]
+      assert.strictEqual(OrderBook.arrayOBMidPrice(book), 1.5)
+    })
+  })
 })

--- a/test/lib/models/position.js
+++ b/test/lib/models/position.js
@@ -46,4 +46,73 @@ describe('Position model', () => {
       assert.ok(o.flags & Order.flags.REDUCE_ONLY, 'position close order does not have pos-close flag set')
     })
   })
+
+  describe('claim', () => {
+    it('throws an error if no interface provided', (done) => {
+      const p = new Position()
+      p.claim().catch(() => done())
+    })
+
+    it('calls claimPosition on the interface', (done) => {
+      const p = new Position({ id: 42 })
+      p.claim({
+        claimPosition: async (id) => {
+          assert.strictEqual(id, 42)
+          done()
+          return []
+        }
+      })
+    })
+
+    it('saves received data on itself', async () => {
+      const p = new Position({ symbol: 'tBTCUSD' })
+      const remoteP = new Position({ symbol: 'just-testing' })
+
+      await p.claim({
+        claimPosition: async () => remoteP.serialize()
+      })
+
+      assert.strictEqual(p.symbol, 'just-testing')
+    })
+  })
+
+  describe('close', () => {
+    it('throws an error if no interface provided', (done) => {
+      const p = new Position()
+      p.close().catch(() => done())
+    })
+
+    it('calls closePosition on the interface', (done) => {
+      const p = new Position({ id: 42 })
+      p.close({
+        closePosition: async ({ position_id }) => { // eslint-disable-line
+          assert.strictEqual(position_id, 42) // eslint-disable-line
+          done()
+        }
+      })
+    })
+  })
+
+  describe('toString', () => {
+    it('includes pertinent information', () => {
+      const p = new Position({
+        symbol: 'tBTCUSD',
+        amount: 42,
+        price: 1,
+        type: 'STOP',
+        hidden: true,
+        postonly: true,
+        reduceonly: true,
+        pl: 9001,
+        liquidationPrice: 33
+      })
+
+      const str = p.toString()
+      assert.ok(/BTC\/USD/.test(str), 'symbol missing')
+      assert.ok(str.indexOf('1') !== -1, 'price missing')
+      assert.ok(str.indexOf('42') !== -1, 'amount missing')
+      assert.ok(str.indexOf('9001') !== -1, 'pl missing')
+      assert.ok(str.indexOf('33') !== -1, 'liq price missing')
+    })
+  })
 })

--- a/test/lib/models/position.js
+++ b/test/lib/models/position.js
@@ -1,8 +1,16 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Position } = require('../../../lib')
+const assert = require('assert')
+const { Position, Order } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+
+const getTestPosition = (opts = {}) => new Position({
+  symbol: 'tLEOUDS',
+  amount: 100,
+  price: 2,
+  ...opts
+})
 
 describe('Position model', () => {
   testModel({
@@ -13,5 +21,29 @@ describe('Position model', () => {
       null, 'id', 'mtsCreate', 'mtsUpdate', null, 'type', null,
       'collateral', 'collateralMin', 'meta'
     ]
+  })
+
+  describe('orderToClose', () => {
+    it('generates a MARKET order', () => {
+      const p = getTestPosition()
+      const o = p.orderToClose()
+
+      assert.strictEqual(o.type, Order.type.MARKET, 'position close order is not a market order')
+    })
+
+    it('generates an order that would close the position', () => {
+      const p = getTestPosition({ amount: 20 })
+      const o = p.orderToClose()
+
+      assert.strictEqual(+o.amount, -20, 'position close order would not close the position')
+    })
+
+    it('sets the reduce-only and pos-close flags', () => {
+      const p = getTestPosition({ amount: 20 })
+      const o = p.orderToClose()
+
+      assert.ok(o.flags & Order.flags.REDUCE_ONLY, 'position close order does not have reduce-only flag set')
+      assert.ok(o.flags & Order.flags.REDUCE_ONLY, 'position close order does not have pos-close flag set')
+    })
   })
 })

--- a/test/lib/models/position.js
+++ b/test/lib/models/position.js
@@ -2,8 +2,12 @@
 'use strict'
 
 const assert = require('assert')
+const { SYMBOLS } = require('bfx-hf-util')
 const { Position, Order } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 
 const getTestPosition = (opts = {}) => new Position({
   symbol: 'tLEOUDS',
@@ -21,6 +25,28 @@ describe('Position model', () => {
       null, 'id', 'mtsCreate', 'mtsUpdate', null, 'type', null,
       'collateral', 'collateralMin', 'meta'
     ]
+  })
+
+  testModelValidation({
+    model: Position,
+    validData: {
+      symbol: VALID_SYMBOLS,
+      status: VALID_SYMBOLS, // grab data from somewhere
+      amount: new Array(...(new Array(5))).map(() => Math.random()),
+      basePrice: new Array(...(new Array(5))).map(() => Math.random()),
+      marginFunding: new Array(...(new Array(5))).map(() => Math.random()),
+      marginFundingType: VALID_SYMBOLS, // grab data from somewhere
+      pl: new Array(...(new Array(5))).map(() => Math.random()),
+      plPerc: new Array(...(new Array(5))).map(() => Math.random()),
+      liquidationPrice: new Array(...(new Array(5))).map(() => Math.random()),
+      leverage: new Array(...(new Array(5))).map(() => Math.random()),
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsCreate: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsUpdate: new Array(...(new Array(5))).map(() => Math.random()),
+      type: VALID_SYMBOLS, // grab data from somewhere
+      collateral: new Array(...(new Array(5))).map(() => Math.random()),
+      collateralMin: new Array(...(new Array(5))).map(() => Math.random())
+    }
   })
 
   describe('orderToClose', () => {

--- a/test/lib/models/public_trade.js
+++ b/test/lib/models/public_trade.js
@@ -12,6 +12,8 @@ describe('Public Trade model', () => {
     orderedFields: ['id', 'mts', 'amount', 'price']
   })
 
+  // TODO: test validation (varies funding/trading)
+
   it('unserializes live trading data correctly', async () => {
     const rest = new RESTv2()
     const arr = await rest.trades('tBTCUSD')

--- a/test/lib/models/public_trade.js
+++ b/test/lib/models/public_trade.js
@@ -9,9 +9,7 @@ const testModel = require('../../helpers/test_model')
 describe('Public Trade model', () => {
   testModel({
     model: PublicTrade,
-    orderedFields: [
-      'id', 'mts', 'amount', 'price'
-    ]
+    orderedFields: ['id', 'mts', 'amount', 'price']
   })
 
   it('unserializes live trading data correctly', async () => {
@@ -39,4 +37,19 @@ describe('Public Trade model', () => {
       })
     })
   }).timeout(60000)
+
+  describe('toString', () => {
+    it('includes pertinent information', () => {
+      const t = new PublicTrade({
+        id: 42,
+        amount: 3,
+        price: 7
+      })
+
+      const str = t.toString()
+      assert.ok(str.indexOf('42') !== -1, 'id missing')
+      assert.ok(str.indexOf('3') !== -1, 'amount missing')
+      assert.ok(str.indexOf('7') !== -1, 'price missing')
+    })
+  })
 })

--- a/test/lib/models/public_trade.js
+++ b/test/lib/models/public_trade.js
@@ -5,6 +5,7 @@ const assert = require('assert')
 const { RESTv2 } = require('bfx-api-node-rest')
 const { PublicTrade } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
 
 describe('Public Trade model', () => {
   testModel({
@@ -12,7 +13,29 @@ describe('Public Trade model', () => {
     orderedFields: ['id', 'mts', 'amount', 'price']
   })
 
-  // TODO: test validation (varies funding/trading)
+  // TODO: Fix this
+  /*
+  testModelValidation({ // funding
+    model: PublicTrade,
+    validData: {
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      mts: new Array(...(new Array(5))).map(() => Math.random()),
+      amount: new Array(...(new Array(5))).map(() => Math.random()),
+      rate: new Array(...(new Array(5))).map(() => Math.random()),
+      period: new Array(...(new Array(5))).map(() => Math.random())
+    }
+  })
+    */
+
+  testModelValidation({ // trading
+    model: PublicTrade,
+    validData: {
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      mts: new Array(...(new Array(5))).map(() => Math.random()),
+      amount: new Array(...(new Array(5))).map(() => Math.random()),
+      price: new Array(...(new Array(5))).map(() => Math.random())
+    }
+  })
 
   it('unserializes live trading data correctly', async () => {
     const rest = new RESTv2()

--- a/test/lib/models/status_messages_deriv.js
+++ b/test/lib/models/status_messages_deriv.js
@@ -1,8 +1,12 @@
 /* eslint-env mocha */
 'use strict'
 
+const { SYMBOLS } = require('bfx-hf-util')
 const { StatusMessagesDeriv } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_STRINGS = Object.values(SYMBOLS)
 
 describe('Derivatives Status Message model', () => {
   testModel({
@@ -11,5 +15,18 @@ describe('Derivatives Status Message model', () => {
       'key', 'timestamp', null, 'price', 'priceSpot', null, 'fundBal', null,
       null, 'fundingAccrued', 'fundingStep'
     ]
+  })
+
+  testModelValidation({
+    model: StatusMessagesDeriv,
+    validData: {
+      key: VALID_STRINGS, // pull data from somewhere
+      timestamp: VALID_STRINGS, // pull data from somewhere
+      price: new Array(...(new Array(5))).map(() => Math.random()),
+      priceSpot: new Array(...(new Array(5))).map(() => Math.random()),
+      fundBal: new Array(...(new Array(5))).map(() => Math.random()),
+      fundingAccrued: new Array(...(new Array(5))).map(() => Math.random()),
+      fundingStep: new Array(...(new Array(5))).map(() => Math.random())
+    }
   })
 })

--- a/test/lib/models/status_messages_deriv.js
+++ b/test/lib/models/status_messages_deriv.js
@@ -1,0 +1,15 @@
+/* eslint-env mocha */
+'use strict'
+
+const { StatusMessagesDeriv } = require('../../../lib')
+const testModel = require('../../helpers/test_model')
+
+describe('Derivatives Status Message model', () => {
+  testModel({
+    model: StatusMessagesDeriv,
+    orderedFields: [
+      'key', 'timestamp', null, 'price', 'priceSpot', null, 'fundBal', null,
+      null, 'fundingAccrued', 'fundingStep'
+    ]
+  })
+})

--- a/test/lib/models/trade.js
+++ b/test/lib/models/trade.js
@@ -2,8 +2,13 @@
 'use strict'
 
 const assert = require('assert')
-const { Trade } = require('../../../lib')
+const { SYMBOLS, CURRENCIES } = require('bfx-hf-util')
+const { Trade, Order } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
+
+const VALID_CURRENCIES = Object.values(CURRENCIES)
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 
 describe('Trade model', () => {
   testModel({
@@ -13,6 +18,23 @@ describe('Trade model', () => {
       'id', 'symbol', 'mtsCreate', 'orderID', 'execAmount', 'execPrice',
       'orderType', 'orderPrice', 'maker', 'fee', 'feeCurrency'
     ]
+  })
+
+  testModelValidation({
+    model: Trade,
+    validData: {
+      symbol: VALID_SYMBOLS,
+      orderID: VALID_SYMBOLS, // get some data
+      orderType: Object.values(Order.type),
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsCreate: new Array(...(new Array(5))).map(() => Math.random()),
+      execAmount: new Array(...(new Array(5))).map(() => Math.random()),
+      execPrice: new Array(...(new Array(5))).map(() => Math.random()),
+      orderPrice: new Array(...(new Array(5))).map(() => Math.random()),
+      maker: new Array(...(new Array(5))).map(() => Math.random() > 0.5),
+      fee: new Array(...(new Array(5))).map(() => Math.random()),
+      feeCurrency: VALID_CURRENCIES
+    }
   })
 
   describe('toString', () => {

--- a/test/lib/models/trade.js
+++ b/test/lib/models/trade.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
+const assert = require('assert')
 const { Trade } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
 
@@ -12,5 +13,28 @@ describe('Trade model', () => {
       'id', 'symbol', 'mtsCreate', 'orderID', 'execAmount', 'execPrice',
       'orderType', 'orderPrice', 'maker', 'fee', 'feeCurrency'
     ]
+  })
+
+  describe('toString', () => {
+    it('includes pertinent information', () => {
+      const t = new Trade({
+        symbol: 'tBTCUSD',
+        id: 1,
+        execAmount: 24,
+        execPrice: 32,
+        maker: true,
+        fee: 7,
+        feeCurrency: 'ETH'
+      })
+
+      const str = t.toString()
+      assert.ok(/tBTCUSD/.test(str), 'symbol missing')
+      assert.ok(str.indexOf('1') !== -1, 'id missing')
+      assert.ok(str.indexOf('32') !== -1, 'exec price missing')
+      assert.ok(str.indexOf('24') !== -1, 'exec amount missing')
+      assert.ok(/maker/.test(str), 'maker flag missing')
+      assert.ok(str.indexOf('7') !== -1, 'fee missing')
+      assert.ok(/ETH/.test(str), 'fee currency missing')
+    })
   })
 })

--- a/test/lib/models/trading_ticker.js
+++ b/test/lib/models/trading_ticker.js
@@ -76,4 +76,18 @@ describe('TradingTicker model', () => {
     assert.strictEqual(obj.high, arr[9])
     assert.strictEqual(obj.low, arr[10])
   })
+
+  describe('base', () => {
+    it('returns the base currency for the ticker', () => {
+      const t = new TradingTicker({ symbol: 'tBTCUSD' })
+      assert.strictEqual(t.base(), 'BTC')
+    })
+  })
+
+  describe('quote', () => {
+    it('returns the quote currency for the ticker', () => {
+      const t = new TradingTicker({ symbol: 'tBTCUSD' })
+      assert.strictEqual(t.quote(), 'USD')
+    })
+  })
 })

--- a/test/lib/models/trading_ticker.js
+++ b/test/lib/models/trading_ticker.js
@@ -2,9 +2,13 @@
 'use strict'
 
 const assert = require('assert')
+const { SYMBOLS } = require('bfx-hf-util')
 const { RESTv2 } = require('bfx-api-node-rest')
 const { TradingTicker } = require('../../../lib')
+const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
 
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 const DATA = [
   'tBTCUSD',
   228.56,
@@ -20,6 +24,31 @@ const DATA = [
 ]
 
 describe('TradingTicker model', () => {
+  testModel({
+    model: TradingTicker,
+    orderedFields: [
+      'symbol', 'bid', 'bidSize', 'ask', 'askSize', 'dailyChange',
+      'dailyChangePerc', 'lastPrice', 'volume', 'high', 'low'
+    ]
+  })
+
+  testModelValidation({
+    model: TradingTicker,
+    validData: {
+      symbol: VALID_SYMBOLS,
+      bid: new Array(...(new Array(5))).map(() => Math.random()),
+      bidSize: new Array(...(new Array(5))).map(() => Math.random()),
+      ask: new Array(...(new Array(5))).map(() => Math.random()),
+      askSize: new Array(...(new Array(5))).map(() => Math.random()),
+      dailyChange: new Array(...(new Array(5))).map(() => Math.random()),
+      dailyChangePerc: new Array(...(new Array(5))).map(() => Math.random()),
+      lastPrice: new Array(...(new Array(5))).map(() => Math.random()),
+      volume: new Array(...(new Array(5))).map(() => Math.random()),
+      high: new Array(...(new Array(5))).map(() => Math.random()),
+      low: new Array(...(new Array(5))).map(() => Math.random())
+    }
+  })
+
   it('initializes correctly', () => {
     const ticker = new TradingTicker(DATA)
 

--- a/test/lib/models/trading_ticker_hist.js
+++ b/test/lib/models/trading_ticker_hist.js
@@ -3,8 +3,12 @@
 
 const assert = require('assert')
 const { RESTv2 } = require('bfx-api-node-rest')
+const { SYMBOLS } = require('bfx-hf-util')
 const { TradingTickerHist } = require('../../../lib')
+const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
 
+const VALID_SYMBOLS = Object.values(SYMBOLS)
 const DATA = [
   'tBTCUSD',
   228.56,
@@ -22,6 +26,24 @@ const DATA = [
 ]
 
 describe('TradingTickerHistory model', () => {
+  testModel({
+    model: TradingTickerHist,
+    orderedFields: [
+      'symbol', 'bid', null, 'ask', null, null, null, null, null, null, null,
+      null, 'mtsUpdate'
+    ]
+  })
+
+  testModelValidation({
+    model: TradingTickerHist,
+    validData: {
+      symbol: VALID_SYMBOLS,
+      bid: new Array(...(new Array(5))).map(() => Math.random()),
+      ask: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsUpdated: new Array(...(new Array(5))).map(() => Math.random())
+    }
+  })
+
   it('initializes correctly', () => {
     const ticker = new TradingTickerHist(DATA)
 

--- a/test/lib/models/trading_ticker_hist.js
+++ b/test/lib/models/trading_ticker_hist.js
@@ -57,4 +57,18 @@ describe('TradingTickerHistory model', () => {
     assert.strictEqual(obj.ask, arr[3])
     assert.strictEqual(obj.mtsUpdate, arr[12])
   })
+
+  describe('base', () => {
+    it('returns the base currency for the ticker', () => {
+      const t = new TradingTickerHist({ symbol: 'tBTCUSD' })
+      assert.strictEqual(t.base(), 'BTC')
+    })
+  })
+
+  describe('quote', () => {
+    it('returns the quote currency for the ticker', () => {
+      const t = new TradingTickerHist({ symbol: 'tBTCUSD' })
+      assert.strictEqual(t.quote(), 'USD')
+    })
+  })
 })

--- a/test/lib/models/user_info.js
+++ b/test/lib/models/user_info.js
@@ -3,6 +3,7 @@
 
 const { UserInfo } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
 
 describe('User info model', () => {
   testModel({
@@ -10,5 +11,15 @@ describe('User info model', () => {
     orderedFields: [
       'id', 'email', 'username', null, null, null, null, 'timezone'
     ]
+  })
+
+  testModelValidation({
+    model: UserInfo,
+    validData: {
+      id: new Array(...(new Array(5))).map(() => Math.random()),
+      email: ['test@test.com', 'what@testing.com', 'really@nope.com'],
+      username: ['not', 'today', 'man', 'but', 'maybe', 'tomorrow'],
+      timezone: ['all', 'over', 'the', 'world', 'vim', 'and', 'all']
+    }
   })
 })

--- a/test/lib/models/user_info.js
+++ b/test/lib/models/user_info.js
@@ -1,0 +1,14 @@
+/* eslint-env mocha */
+'use strict'
+
+const { UserInfo } = require('../../../lib')
+const testModel = require('../../helpers/test_model')
+
+describe('User info model', () => {
+  testModel({
+    model: UserInfo,
+    orderedFields: [
+      'id', 'email', 'username', null, null, null, null, 'timezone'
+    ]
+  })
+})

--- a/test/lib/models/wallet.js
+++ b/test/lib/models/wallet.js
@@ -1,14 +1,73 @@
 /* eslint-env mocha */
 'use strict'
 
+const _flattenDeep = require('lodash/flattenDeep')
+const _sample = require('lodash/sample')
+const { CURRENCIES } = require('bfx-hf-util')
 const { Wallet } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
 
-describe('Wallet model', () => {
+const GENERIC_INVALID_FIELDS = [false, '', undefined, []]
+const VALID_TYPES = Object.values(Wallet.type)
+const VALID_CURRENCIES = Object.values(CURRENCIES)
+const VALID_DESCRIPTIONS = [null, 'some description']
+const VALID_META = [null, { reason: 'TRADE' }]
+
+const genWallet = (overrides = {}) => ({
+  type: _sample(VALID_TYPES),
+  currency: _sample(VALID_CURRENCIES),
+  balance: Math.random(),
+  balanceAvailable: Math.random(),
+  unsettledInterest: Math.random(),
+  description: _sample(VALID_DESCRIPTIONS),
+  meta: _sample(VALID_META),
+
+  ...overrides
+})
+
+describe('Wallet', () => {
   testModel({
     model: Wallet,
     orderedFields: [
       'type', 'currency', 'balance', 'unsettledInterest', 'balanceAvailable'
     ]
+  })
+
+  testModelValidation({
+    model: Wallet,
+    invalid: _flattenDeep([
+      [42, ...GENERIC_INVALID_FIELDS].map(v => genWallet({ meta: v })),
+      [42, {}, ...GENERIC_INVALID_FIELDS].map(v => [
+        genWallet({ type: v }),
+        genWallet({ currency: v })
+      ]),
+
+      [{}, ...GENERIC_INVALID_FIELDS].map(v => [
+        genWallet({ type: v }),
+        genWallet({ currency: v }),
+        genWallet({ balance: v }),
+        genWallet({ unsettledInterest: v }),
+        genWallet({ balanceAvailable: v })
+      ])
+    ]),
+
+    // TODO: Extract this strange nesting into a helper function
+    valid: _flattenDeep([
+      VALID_TYPES.map(type => (
+        VALID_CURRENCIES.map(currency => (
+          VALID_DESCRIPTIONS.map(description => (
+            VALID_META.map(meta => (
+              genWallet({
+                meta,
+                type,
+                currency,
+                describe
+              })
+            ))
+          ))
+        ))
+      ))
+    ])
   })
 })

--- a/test/lib/models/wallet.js
+++ b/test/lib/models/wallet.js
@@ -1,30 +1,10 @@
 /* eslint-env mocha */
 'use strict'
 
-const _flattenDeep = require('lodash/flattenDeep')
-const _sample = require('lodash/sample')
-const { CURRENCIES } = require('bfx-hf-util')
+const { CURRENCIES, WALLET_TYPES } = require('bfx-hf-util')
 const { Wallet } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
 const testModelValidation = require('../../helpers/test_model_validation')
-
-const GENERIC_INVALID_FIELDS = [false, '', undefined, []]
-const VALID_TYPES = Object.values(Wallet.type)
-const VALID_CURRENCIES = Object.values(CURRENCIES)
-const VALID_DESCRIPTIONS = [null, 'some description']
-const VALID_META = [null, { reason: 'TRADE' }]
-
-const genWallet = (overrides = {}) => ({
-  type: _sample(VALID_TYPES),
-  currency: _sample(VALID_CURRENCIES),
-  balance: Math.random(),
-  balanceAvailable: Math.random(),
-  unsettledInterest: Math.random(),
-  description: _sample(VALID_DESCRIPTIONS),
-  meta: _sample(VALID_META),
-
-  ...overrides
-})
 
 describe('Wallet', () => {
   testModel({
@@ -36,38 +16,14 @@ describe('Wallet', () => {
 
   testModelValidation({
     model: Wallet,
-    invalid: _flattenDeep([
-      [42, ...GENERIC_INVALID_FIELDS].map(v => genWallet({ meta: v })),
-      [42, {}, ...GENERIC_INVALID_FIELDS].map(v => [
-        genWallet({ type: v }),
-        genWallet({ currency: v })
-      ]),
-
-      [{}, ...GENERIC_INVALID_FIELDS].map(v => [
-        genWallet({ type: v }),
-        genWallet({ currency: v }),
-        genWallet({ balance: v }),
-        genWallet({ unsettledInterest: v }),
-        genWallet({ balanceAvailable: v })
-      ])
-    ]),
-
-    // TODO: Extract this strange nesting into a helper function
-    valid: _flattenDeep([
-      VALID_TYPES.map(type => (
-        VALID_CURRENCIES.map(currency => (
-          VALID_DESCRIPTIONS.map(description => (
-            VALID_META.map(meta => (
-              genWallet({
-                meta,
-                type,
-                currency,
-                describe
-              })
-            ))
-          ))
-        ))
-      ))
-    ])
+    validData: {
+      type: Object.values(WALLET_TYPES),
+      currency: Object.values(CURRENCIES),
+      description: [null, ...Object.values(CURRENCIES)],
+      meta: [null, ...Object.values(CURRENCIES).map(reason => ({ reason: 'TRADE' }))], // need a data source
+      balance: new Array(...(new Array(5))).map(() => Math.random()),
+      balanceAvailable: new Array(...(new Array(5))).map(() => Math.random()),
+      unsettledInterest: new Array(...(new Array(5))).map(() => Math.random())
+    }
   })
 })

--- a/test/lib/models/wallet_hist.js
+++ b/test/lib/models/wallet_hist.js
@@ -1,8 +1,10 @@
 /* eslint-env mocha */
 'use strict'
 
+const { CURRENCIES, WALLET_TYPES } = require('bfx-hf-util')
 const { WalletHist } = require('../../../lib')
 const testModel = require('../../helpers/test_model')
+const testModelValidation = require('../../helpers/test_model_validation')
 
 describe('Historical wallet model', () => {
   testModel({
@@ -10,5 +12,17 @@ describe('Historical wallet model', () => {
     orderedFields: [
       'type', 'currency', 'balance', 'unsettledInterest', 'balanceAvailable', null, 'mtsUpdate'
     ]
+  })
+
+  testModelValidation({
+    model: WalletHist,
+    validData: {
+      type: Object.values(WALLET_TYPES),
+      currency: Object.values(CURRENCIES),
+      balance: new Array(...(new Array(5))).map(() => Math.random()),
+      balanceAvailable: new Array(...(new Array(5))).map(() => Math.random()),
+      unsettledInterest: new Array(...(new Array(5))).map(() => Math.random()),
+      mtsUpdate: new Array(...(new Array(5))).map(() => Math.random())
+    }
   })
 })

--- a/test/lib/util/assign_from_collection_or_instance.js
+++ b/test/lib/util/assign_from_collection_or_instance.js
@@ -1,0 +1,98 @@
+'use strict'
+/* eslint-env mocha */
+
+const assert = require('assert')
+const _isArray = require('lodash/isArray')
+const _isObject = require('lodash/isObject')
+const _isFinite = require('lodash/isFinite')
+const isCollection = require('../../../lib/util/is_collection')
+const assignFromCollectionOrInstance = require('../../../lib/util/assign_from_collection_or_instance')
+
+describe('static assignFromCollectionOrInstance', () => {
+  it('correctly assigns object values', () => {
+    class TestModel {
+      static unserialize (data) {
+        assert(_isObject(data))
+        assert.deepStrictEqual(Object.keys(data), { a: 5, b: 42 })
+
+        return data // already object
+      }
+    }
+
+    const data = { a: 5, b: 42 }
+    const target = new TestModel()
+
+    assignFromCollectionOrInstance({ data, target })
+
+    assert.strictEqual(target.a, 5)
+    assert.strictEqual(target.b, 42)
+  })
+
+  it('correctly assigns an array of objects via iterator', () => {
+    class TestModel {
+      static unserialize (data) {
+        if (isCollection(data)) {
+          return data.map(TestModel.unserialize)
+        }
+
+        assert(_isObject(data))
+        assert.deepStrictEqual(Object.keys(data), ['a'])
+
+        return data // already object
+      }
+    }
+
+    const data = [{ a: 0 }, { a: 1 }, { a: 2 }, { a: 3 }]
+    const target = new TestModel()
+
+    assignFromCollectionOrInstance({ data, target })
+
+    assert.strictEqual(target.length, 4)
+    assert.deepStrictEqual(target[0], { a: 0 })
+    assert.deepStrictEqual(target[1], { a: 1 })
+    assert.deepStrictEqual(target[2], { a: 2 })
+    assert.deepStrictEqual(target[3], { a: 3 })
+  })
+
+  it('correctly assigns an array of arrays via iterator', () => {
+    class TestModel {
+      static unserialize (data) {
+        if (isCollection(data)) {
+          return data.map(TestModel.unserialize)
+        }
+
+        assert(_isArray(data))
+        assert.strictEqual(data.length, 1)
+        assert(_isFinite(data[0]))
+
+        return { a: data[0] }
+      }
+    }
+
+    const data = [[0], [1], [2], [3]]
+    const target = new TestModel()
+
+    assignFromCollectionOrInstance({ data, target })
+
+    assert.strictEqual(target.length, 4)
+    assert.deepStrictEqual(target[0], { a: 0 })
+    assert.deepStrictEqual(target[1], { a: 1 })
+    assert.deepStrictEqual(target[2], { a: 2 })
+    assert.deepStrictEqual(target[3], { a: 3 })
+  })
+
+  it('correctly assigns an array model via unserialize', (done) => {
+    class TestModel {
+      static unserialize (data) {
+        assert.strictEqual(data.length, 4)
+        assert.deepStrictEqual(data, [0, 1, 2, 3])
+        done()
+      }
+    }
+
+    const data = [0, 1, 2, 3]
+    const target = new TestModel()
+
+    assignFromCollectionOrInstance({ data, target })
+  })
+})

--- a/test/lib/util/is_collection.js
+++ b/test/lib/util/is_collection.js
@@ -1,0 +1,13 @@
+'use strict'
+/* eslint-env mocha */
+
+const assert = require('assert')
+const isCollection = require('../../../lib/util/is_collection')
+
+describe('isCollection', () => {
+  it('false for a single array', () => assert(!isCollection([])))
+  it('false for a single object', () => assert(!isCollection({})))
+  it('true for an array of arrays', () => assert(isCollection([[], []])))
+  it('true for an array of objects', () => assert(isCollection([{}, {}])))
+  it('true for an array of mixed arrays and objects', () => assert(isCollection([[], {}])))
+})

--- a/test/lib/validators/amount.js
+++ b/test/lib/validators/amount.js
@@ -1,0 +1,20 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const _isEmpty = require('lodash/isEmpty')
+const validator = require('../../../lib/validators/amount')
+
+describe('amount validator', () => {
+  it('returns no error if given a number', () => {
+    assert.strictEqual(validator(42), null, 'failed validation for a number')
+  })
+
+  it('returns an error for any other value', () => {
+    assert.ok(!_isEmpty(validator('42')), 'passed validation for number')
+    assert.ok(!_isEmpty(validator({})), 'passed validation for object')
+    assert.ok(!_isEmpty(validator([])), 'passed validation for array')
+    assert.ok(!_isEmpty(validator(true)), 'passed validation for bool')
+    assert.ok(!_isEmpty(validator(() => {})), 'passed validation for func')
+  })
+})

--- a/test/lib/validators/bool.js
+++ b/test/lib/validators/bool.js
@@ -1,0 +1,21 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const _isEmpty = require('lodash/isEmpty')
+const validator = require('../../../lib/validators/bool')
+
+describe('bool validator', () => {
+  it('returns no error if given a bool', () => {
+    assert.strictEqual(validator(true), null, 'failed validation for true')
+    assert.strictEqual(validator(false), null, 'failed validation for false')
+  })
+
+  it('returns an error for any other value', () => {
+    assert.ok(!_isEmpty(validator(3)), 'passed validation for number')
+    assert.ok(!_isEmpty(validator('42')), 'passed validation for number')
+    assert.ok(!_isEmpty(validator({})), 'passed validation for object')
+    assert.ok(!_isEmpty(validator([])), 'passed validation for array')
+    assert.ok(!_isEmpty(validator(() => {})), 'passed validation for func')
+  })
+})

--- a/test/lib/validators/currency.js
+++ b/test/lib/validators/currency.js
@@ -1,0 +1,29 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const _isEmpty = require('lodash/isEmpty')
+const { CURRENCIES } = require('bfx-hf-util')
+const validator = require('../../../lib/validators/currency')
+
+const VALID_CURRENCIES = Object.values(CURRENCIES)
+
+describe('currency validator', () => {
+  it('returns no error for known currencies', () => {
+    VALID_CURRENCIES.forEach((ccy) => {
+      assert.strictEqual(validator(ccy), null, 'failed validation for known currency')
+    })
+  })
+
+  it('returns an error for any other value', () => {
+    VALID_CURRENCIES.forEach((ccy) => {
+      assert.ok(!_isEmpty(validator(`__${ccy}`)), 'passed validation for unknown currency')
+    })
+
+    assert.ok(!_isEmpty(validator(42)), 'passed validation for number')
+    assert.ok(!_isEmpty(validator({})), 'passed validation for object')
+    assert.ok(!_isEmpty(validator([])), 'passed validation for array')
+    assert.ok(!_isEmpty(validator(true)), 'passed validation for bool')
+    assert.ok(!_isEmpty(validator(() => {})), 'passed validation for func')
+  })
+})

--- a/test/lib/validators/date.js
+++ b/test/lib/validators/date.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const _isEmpty = require('lodash/isEmpty')
+const validator = require('../../../lib/validators/date')
+
+describe('date validator', () => {
+  it('returns no error if given a number gte zero', () => {
+    assert.strictEqual(validator(0), null, 'failed validation for a number gte zero')
+    assert.strictEqual(validator(1), null, 'failed validation for a number gte zero')
+  })
+
+  it('returns no error if given a date', () => {
+    assert.strictEqual(validator(new Date()), null, 'failed validation for a number gte zero')
+  })
+
+  it('returns an error for any other value', () => {
+    assert.ok(!_isEmpty(validator(-1)), 'passed validation for negative number')
+    assert.ok(!_isEmpty(validator('test')), 'passed validation for object')
+    assert.ok(!_isEmpty(validator({ test: 42 })), 'passed validation for object')
+    assert.ok(!_isEmpty(validator(['test'])), 'passed validation for array')
+    assert.ok(!_isEmpty(validator(() => {})), 'passed validation for func')
+  })
+})

--- a/test/lib/validators/number.js
+++ b/test/lib/validators/number.js
@@ -1,0 +1,20 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const _isEmpty = require('lodash/isEmpty')
+const validator = require('../../../lib/validators/number')
+
+describe('number validator', () => {
+  it('returns no error if given a number', () => {
+    assert.strictEqual(validator(42), null, 'failed validation for a number')
+  })
+
+  it('returns an error for any other value', () => {
+    assert.ok(!_isEmpty(validator('42')), 'passed validation for number')
+    assert.ok(!_isEmpty(validator({})), 'passed validation for object')
+    assert.ok(!_isEmpty(validator([])), 'passed validation for array')
+    assert.ok(!_isEmpty(validator(true)), 'passed validation for bool')
+    assert.ok(!_isEmpty(validator(() => {})), 'passed validation for func')
+  })
+})

--- a/test/lib/validators/price.js
+++ b/test/lib/validators/price.js
@@ -1,0 +1,22 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const _isEmpty = require('lodash/isEmpty')
+const validator = require('../../../lib/validators/price')
+
+describe('price validator', () => {
+  it('returns no error if given a number gte zero', () => {
+    assert.strictEqual(validator(0), null, 'failed validation for a number gte zero')
+    assert.strictEqual(validator(1), null, 'failed validation for a number gte zero')
+  })
+
+  it('returns an error for any other value', () => {
+    assert.ok(!_isEmpty(validator(-1)), 'passed validation for negative number')
+    assert.ok(!_isEmpty(validator('42')), 'passed validation for number')
+    assert.ok(!_isEmpty(validator({})), 'passed validation for object')
+    assert.ok(!_isEmpty(validator([])), 'passed validation for array')
+    assert.ok(!_isEmpty(validator(true)), 'passed validation for bool')
+    assert.ok(!_isEmpty(validator(() => {})), 'passed validation for func')
+  })
+})

--- a/test/lib/validators/string.js
+++ b/test/lib/validators/string.js
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const _isEmpty = require('lodash/isEmpty')
+const validator = require('../../../lib/validators/string')
+
+describe('string validator', () => {
+  it('returns no error if given a string', () => {
+    assert.strictEqual(validator(''), null, 'failed validation for a string')
+  })
+
+  it('returns an error if given a filter list and a value not in the list', () => {
+    assert.ok(!_isEmpty(validator('not-test', ['test'])), 'passed validation for an unknown string')
+  })
+
+  it('returns no error if given a filter list and a value in the list', () => {
+    assert.strictEqual(validator('test', ['test']), null, 'failed validation for a known string')
+  })
+
+  it('returns an error for any other value', () => {
+    assert.ok(!_isEmpty(validator(42)), 'passed validation for number')
+    assert.ok(!_isEmpty(validator({})), 'passed validation for object')
+    assert.ok(!_isEmpty(validator([])), 'passed validation for array')
+    assert.ok(!_isEmpty(validator(true)), 'passed validation for bool')
+    assert.ok(!_isEmpty(validator(() => {})), 'passed validation for func')
+  })
+})

--- a/test/lib/validators/symbol.js
+++ b/test/lib/validators/symbol.js
@@ -1,0 +1,29 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const _isEmpty = require('lodash/isEmpty')
+const { SYMBOLS } = require('bfx-hf-util')
+const validator = require('../../../lib/validators/symbol')
+
+const VALID_SYMBOLS = Object.values(SYMBOLS)
+
+describe('symbol validator', () => {
+  it('returns no error for known symbols', () => {
+    VALID_SYMBOLS.forEach((sym) => {
+      assert.strictEqual(validator(sym), null, 'failed validation for known symbol')
+    })
+  })
+
+  it('returns an error for any other value', () => {
+    VALID_SYMBOLS.forEach((sym) => {
+      assert.ok(!_isEmpty(validator(`__${sym}`)), 'passed validation for unknown symbol')
+    })
+
+    assert.ok(!_isEmpty(validator(42)), 'passed validation for number')
+    assert.ok(!_isEmpty(validator({})), 'passed validation for object')
+    assert.ok(!_isEmpty(validator([])), 'passed validation for array')
+    assert.ok(!_isEmpty(validator(true)), 'passed validation for bool')
+    assert.ok(!_isEmpty(validator(() => {})), 'passed validation for func')
+  })
+})


### PR DESCRIPTION
### Description:
Adds support for built-in model field validation, and refactors core `Model` method signatures slightly decreasing the number of parameters that must be provided for model definitions. Also adds more tests!

### TODO
- [x] add validators to all models
- [x] add more (as complete as possible) unit/integration tests

### Breaking changes:
- [x] `Model` constructor now takes a map instead of a series of arguments
- [x] `Model.unserialize` now takes a map instead of a series of arguments
- [x] `Order._modifyFlag()` is now public as `Order.modifyFlag()`

### New features:
- [x] `fieldKeys` no longer needs to be provided when creating a new model
- [x] `boolFields` is now optional when creating a new model
- [x] added `Model.validate()`
- [x] added validation to all models
- [x] added `isCollection`
- [x] switched to `async/await` where possible
- [x] added `description` and `meta` field support to `Wallet` model
- [x] added `nyc` and set/enforced limits
- [x] added husky `npm test` pre-commit hook
- [x] more tests!

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
