### PR TITLE
(fix) mv bfx-hf-util and bfx-api-node-rest to deps from dev deps 1.2.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.2.1
+- fix: move bfx-hf-util and bfx-api-node-rest to deps from dev deps
+
 # 1.2.0
 - meta: bumped dependencies
 - meta: added husky pre-commit test hook

--- a/package.json
+++ b/package.json
@@ -45,8 +45,6 @@
     "babel-eslint": "^10.1.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-regenerator": "^6.26.0",
-    "bfx-api-node-rest": "^3.0.3",
-    "bfx-hf-util": "^1.0.6",
     "chai": "^4.2.0",
     "husky": "^4.2.3",
     "jsdoc-to-markdown": "^5.0.3",
@@ -56,6 +54,8 @@
   },
   "dependencies": {
     "bfx-api-node-util": "^1.0.8",
+    "bfx-api-node-rest": "^3.0.3",
+    "bfx-hf-util": "^1.0.6",
     "bluebird": "^3.7.2",
     "crc-32": "^1.2.0",
     "debug": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
...

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
