### PR TITLE
Fix: Make bfx-api-node-rest dev-dep to break circular dep 1.2.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.2.2
+- fix: make bfx-api-node-rest dev-dep to break circular dependency
+
 # 1.2.1
 - fix: move bfx-hf-util and bfx-api-node-rest to deps from dev deps
 

--- a/lib/funding_offer.js
+++ b/lib/funding_offer.js
@@ -3,7 +3,6 @@
 const _filter = require('lodash/filter')
 const _flatten = require('lodash/flatten')
 const _isEmpty = require('lodash/isEmpty')
-const { RESTv2 } = require('bfx-api-node-rest')
 const { prepareAmount, preparePrice } = require('bfx-api-node-util')
 
 const numberValidator = require('./validators/number')
@@ -94,7 +93,7 @@ class FundingOffer extends Model {
    * @return {Promise} p
    */
   async submit (apiInterface = this._apiInterface) {
-    if (!(apiInterface instanceof RESTv2)) {
+    if (!apiInterface) {
       throw new Error('no API interface provided')
     }
 
@@ -111,7 +110,7 @@ class FundingOffer extends Model {
    * @return {Promise} p
    */
   async cancel (apiInterface = this._apiInterface) {
-    if (!(apiInterface instanceof RESTv2)) {
+    if (!apiInterface) {
       throw new Error('no API interface provided')
     }
 
@@ -128,7 +127,7 @@ class FundingOffer extends Model {
    * @return {Promise} p
    */
   async close (apiInterface = this._apiInterface) {
-    if (!(apiInterface instanceof RESTv2)) {
+    if (!apiInterface) {
       throw new Error('no API interface provided')
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=7"
@@ -45,6 +45,7 @@
     "babel-eslint": "^10.1.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-regenerator": "^6.26.0",
+    "bfx-api-node-rest": "^3.0.3",
     "chai": "^4.2.0",
     "husky": "^4.2.3",
     "jsdoc-to-markdown": "^5.0.3",
@@ -54,7 +55,6 @@
   },
   "dependencies": {
     "bfx-api-node-util": "^1.0.8",
-    "bfx-api-node-rest": "^3.0.3",
     "bfx-hf-util": "^1.0.6",
     "bluebird": "^3.7.2",
     "crc-32": "^1.2.0",


### PR DESCRIPTION
### Description:
Removes the `instanceOf` check for a RESTv2 api interface in `FundingOffer`, as we cannot include `bfx-api-node-rest` in non-test files.

### Fixes:
- [x] breaks circular dependency with `bfx-api-node-rest`

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
