### PR TITLE
Fix: Index lookup in validation of array-format models 1.2.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.2.3
+- fix: index lookup in validation of array-format models
+
 # 1.2.2
 - fix: make bfx-api-node-rest dev-dep to break circular dependency
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -128,7 +128,6 @@ class Model extends EventEmitter {
       })).find(result => result instanceof Error) || null // return first error
     }
 
-    const fieldKeys = Object.keys(fields)
     const keys = Object.keys(validators)
 
     let key
@@ -137,7 +136,7 @@ class Model extends EventEmitter {
     for (let i = 0; i < keys.length; i += 1) {
       key = keys[i]
       instanceValue = _isArray(data)
-        ? data[fieldKeys[key]]
+        ? data[fields[key]]
         : data[key]
 
       if (_isFunction(validators[key])) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
This was overlooked as validation tests only use object models; skipping the addition of array-format validation testing now due to the need to specify key-index maps for each model type, whereas object keys are inferred from the valid datasets passed to the validation test helper. Example of a helper call that would need to be updated:

```js
  testModelValidation({ // trading
    model: PublicTrade,
    validData: {
      id: new Array(...(new Array(5))).map(() => Math.random()),
      mts: new Array(...(new Array(5))).map(() => Math.random()),
      amount: new Array(...(new Array(5))).map(() => Math.random()),
      price: new Array(...(new Array(5))).map(() => Math.random())
    }
  })
```

### Fixes:
- [x] Index lookup for array-format models in base `Model.validate()` method

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
