### PR TITLE
Extend the StatusMessagesDeriv model with all the available values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+# 1.2.12
+- feature: add fundingEventTimestamp to StatusMessagesDeriv model
+- feature: add currentFunding to StatusMessagesDeriv model
+- feature: add markprice to StatusMessagesDeriv model
+- feature: add openInterest to StatusMessagesDeriv model
+
 # 1.2.11
 - feature: add clampMin to StatusMessagesDeriv model
 - feature: add clampMax to StatusMessagesDeriv model

--- a/lib/status_messages_deriv.js
+++ b/lib/status_messages_deriv.js
@@ -10,8 +10,12 @@ const fields = {
   price: 3,
   priceSpot: 4,
   fundBal: 6,
+  fundingEventTimestamp: 8,
   fundingAccrued: 9,
   fundingStep: 10,
+  currentFunding: 12,
+  markprice: 15,
+  openInterest: 18,
   clampMin: 22,
   clampMax: 23
 }
@@ -27,8 +31,12 @@ class StatusMessagesDeriv extends Model {
    * @param {string} data.price - price
    * @param {string} data.priceSpot - spot price
    * @param {string} data.fundBal - funding balance
+   * @param {number} data.fundingEventTimestamp - timestamp
    * @param {string} data.fundingAccrued - accrued funding
    * @param {string} data.fundingStep - funding step
+   * @param {number} data.currentFunding - funding applied in the current 8h period,
+   * @param {number} data.markprice - markprice,
+   * @param {number} data.openInterest - total number of outstanding derivative contracts,
    * @param {number} data.clampMin - min clamp
    * @param {number} data.clampMax - max clamp
    */
@@ -60,8 +68,12 @@ class StatusMessagesDeriv extends Model {
         price: priceValidator,
         priceSpot: priceValidator,
         fundBal: priceValidator,
+        fundingEventTimestamp: stringValidator,
         fundingAccrued: priceValidator,
         fundingStep: priceValidator,
+        currentFunding: priceValidator,
+        markprice: priceValidator,
+        openInterest: priceValidator,
         clampMin: priceValidator,
         clampMax: priceValidator
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=8.3.0"

--- a/test/lib/models/status_messages_deriv.js
+++ b/test/lib/models/status_messages_deriv.js
@@ -13,8 +13,9 @@ describe('Derivatives Status Message model', () => {
     model: StatusMessagesDeriv,
     orderedFields: [
       'key', 'timestamp', null, 'price', 'priceSpot', null, 'fundBal', null,
-      null, 'fundingAccrued', 'fundingStep', null, null, null, null, null,
-      null, null, null, null, null, null, 'clampMin', 'clampMax'
+      'fundingEventTimestamp', 'fundingAccrued', 'fundingStep', null,
+      'currentFunding', null, null, 'markprice', null, null, 'openInterest',
+      null, null, null, 'clampMin', 'clampMax'
     ]
   })
 
@@ -26,8 +27,12 @@ describe('Derivatives Status Message model', () => {
       price: new Array(5).fill().map(Math.random),
       priceSpot: new Array(5).fill().map(Math.random),
       fundBal: new Array(5).fill().map(Math.random),
+      fundingEventTimestamp: VALID_STRINGS,
       fundingAccrued: new Array(5).fill().map(Math.random),
       fundingStep: new Array(5).fill().map(Math.random),
+      currentFunding: new Array(5).fill().map(Math.random),
+      markprice: new Array(5).fill().map(Math.random),
+      openInterest: new Array(5).fill().map(Math.random),
       clampMin: new Array(5).fill().map(Math.random),
       clampMax: new Array(5).fill().map(Math.random)
     }


### PR DESCRIPTION
### Description:
Extending the StatusMessagesDeriv Model with all available values.

### New features:
- [x] feature: add fundingEventTimestamp to StatusMessagesDeriv model
- [x] feature: add currentFunding to StatusMessagesDeriv model
- [x] feature: add markprice to StatusMessagesDeriv model
- [x] feature: add openInterest to StatusMessagesDeriv model

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Tests added or updated
