### PR TITLE
Validate updateWith's input parameters

### DIFF
--- a/lib/order_book.js
+++ b/lib/order_book.js
@@ -220,6 +220,10 @@ class OrderBook extends EventEmitter {
       ? entry.length === 4 ? 2 : 1
       : 0
     const numEntry = entry.map((x) => Number(x))
+    const isValid = numEntry.every(value => Number.isFinite(value))
+
+    if (!isValid) throw new Error('the entry is not valid (should contain only numbers)')
+
     const count = raw ? -1 : numEntry.length === 4 ? numEntry[2] : numEntry[1]
     const price = numEntry[priceI]
     const oID = numEntry[0] // only for raw books


### PR DESCRIPTION
Validate input parameters of OrderBook's `updateWith` method. This allows to localize the issues such as appeared in [the ticket](https://app.asana.com/0/1125859137800433/1200479993218088)

Additional checks are needed in other packages that depend on this one, since it can lead to the crash of the application instead of ignoring invalid data like in the https://github.com/bitfinexcom/bfx-api-node-plugin-managed-ob/pull/6

