### PR TITLE
Add visible on hit hidden orders

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+#1.6.2
+- feature: visible on hit option supported for hidden orders
+
 # 1.6.0
 - feature: Core settings model
 

--- a/lib/order.js
+++ b/lib/order.js
@@ -8,6 +8,7 @@ const _isEmpty = require('lodash/isEmpty')
 const _compact = require('lodash/compact')
 const _flatten = require('lodash/flatten')
 const _includes = require('lodash/includes')
+const _isBoolean = require('lodash/isBoolean')
 const _isUndefined = require('lodash/isUndefined')
 const { prepareAmount, preparePrice } = require('bfx-api-node-util')
 
@@ -101,6 +102,7 @@ class Order extends Model {
 
     if (!this.flags) this.flags = 0
     if (!_isUndefined(data.hidden)) this.setHidden(data.hidden)
+    if (!_isUndefined(data.visibleOnHit)) this.setVisibleOnHit(data.visibleOnHit)
     if (!_isUndefined(data.postonly)) this.setPostOnly(data.postonly)
     if (!_isUndefined(data.reduceonly)) this.setReduceOnly(data.reduceonly)
     if (!_isUndefined(data.oco)) {
@@ -159,6 +161,7 @@ class Order extends Model {
       /market/.test(type.toLowerCase()) ? 'MARKET' : preparePrice(price),
 
       this.isHidden() && 'hidden',
+      this.isVisibleOnHit() && 'visible-on-hit',
       this.isPostOnly() && 'post-only',
       this.isReduceOnly() && 'reduce-only',
       this.isPositionClose() && 'pos-close',
@@ -180,6 +183,13 @@ class Order extends Model {
    */
   isHidden () {
     return !!(this.flags & Order.flags.HIDDEN)
+  }
+
+  /**
+   * @returns {boolean} visibleOnHit
+   */
+  isVisibleOnHit () {
+    return !!(this.isHidden() && this.meta && this.meta.make_visible)
   }
 
   /**
@@ -236,7 +246,30 @@ class Order extends Model {
    * @returns {number} finalFlags
    */
   setHidden (v) {
+    if (!v) {
+      delete this.meta?.make_visible
+    }
     return this.modifyFlag(Order.flags.HIDDEN, v)
+  }
+
+  /**
+   * Update the meta object. The rest part of the hidden order will be visible
+   * after first hit(partial execution).
+   *
+   * @param {boolean} v - visibleOnHit value
+   * @returns {number} meta
+   */
+  setVisibleOnHit (v) {
+    if (!this.isHidden() || !_isBoolean(v)) {
+      return
+    }
+
+    this.meta = {
+      ...(this.meta || {}),
+      make_visible: +v
+    }
+
+    return this.meta
   }
 
   /**

--- a/lib/order.js
+++ b/lib/order.js
@@ -246,8 +246,8 @@ class Order extends Model {
    * @returns {number} finalFlags
    */
   setHidden (v) {
-    if (!v) {
-      delete this.meta?.make_visible
+    if (!v && this.meta) {
+      delete this.meta.make_visible
     }
     return this.modifyFlag(Order.flags.HIDDEN, v)
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=8.3.0"

--- a/test/lib/models/order.js
+++ b/test/lib/models/order.js
@@ -169,6 +169,23 @@ describe('Order model', () => {
     assert(o.isHidden())
   })
 
+  it('isVisibleOnHit, setVisibleOnHit: updates/reads if the hidden orders are visible on hit or not', () => {
+    const o = new Order()
+    assert(!o.isHidden())
+    assert(!o.isVisibleOnHit())
+
+    o.setVisibleOnHit(true)
+    assert(!o.isVisibleOnHit())
+
+    o.setHidden(true)
+    o.setVisibleOnHit(true)
+    assert(o.isVisibleOnHit())
+
+    o.setHidden(false)
+    assert(!o.isHidden())
+    assert(!o.isVisibleOnHit())
+  })
+
   it('isPostOnly, setPostOnly: updates/reads postonly flag', () => {
     const o = new Order()
     assert(!o.isPostOnly())


### PR DESCRIPTION
### Description:
Added visible on hit method for hidden orders.

### New features:
- [x] allow users to submit visible on hit feature for hidden orders

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Tests added or updated
- [ ] Documentation updated
