### PR TITLE
Change models to support new rest api signature

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,14 @@
-#1.7.0
+# 1.7.1
+- fix: Change FundingOffer, Order, Position model to support new rest api signature
+- fix: Test coverage to support new rest api signature
+
+# 1.7.0
 - feature: Currency Movement Info model
 
-#1.6.3
+# 1.6.3
 - fix: public trade unserializing from snapshot
 
-#1.6.2
+# 1.6.2
 - feature: visible on hit option supported for hidden orders
 
 # 1.6.0

--- a/lib/funding_offer.js
+++ b/lib/funding_offer.js
@@ -98,7 +98,7 @@ class FundingOffer extends Model {
       throw new Error('no API interface provided')
     }
 
-    return apiInterface.submitFundingOffer(this).then((offerArray) => {
+    return apiInterface.submitFundingOffer({ offer: this }).then((offerArray) => {
       Object.assign(this, FundingOffer.unserialize(offerArray))
       return this
     })
@@ -115,7 +115,7 @@ class FundingOffer extends Model {
       throw new Error('no API interface provided')
     }
 
-    return apiInterface.cancelFundingOffer(this.id).then((offerArray) => {
+    return apiInterface.cancelFundingOffer({ id: this.id }).then((offerArray) => {
       Object.assign(this, FundingOffer.unserialize(offerArray))
       return this
     })

--- a/lib/order.js
+++ b/lib/order.js
@@ -482,7 +482,7 @@ class Order extends Model {
       throw new Error('no API interface provided')
     }
 
-    const orderArr = await apiInterface.submitOrder(this)
+    const orderArr = await apiInterface.submitOrder({ order: this })
     Object.assign(this, Order.unserialize(orderArr))
     return this
   }
@@ -497,7 +497,7 @@ class Order extends Model {
     if (!apiInterface) throw new Error('no API interface provided')
     if (!this.id) throw new Error('order has no ID')
 
-    return apiInterface.cancelOrder(this.id)
+    return apiInterface.cancelOrder({ id: this.id })
   }
 
   /**

--- a/lib/position.js
+++ b/lib/position.js
@@ -85,7 +85,7 @@ class Position extends Model {
       throw new Error('claim position only supported on RESTv2')
     }
 
-    return apiInterface.claimPosition(this.id).then((positionArray) => {
+    return apiInterface.claimPosition({ id: this.id }).then((positionArray) => {
       Object.assign(this, Position.unserialize(positionArray))
       return this
     })

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "http://bitfinexcom.github.io/bfx-api-node-models/",
   "devDependencies": {
-    "bfx-api-node-rest": "^4.1.2",
+    "bfx-api-node-rest": "^5.1.0",
     "chai": "^4.2.0",
     "docdash": "^1.2.0",
     "husky": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-models",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Object models for usage with the Bitfinex node API",
   "engines": {
     "node": ">=8.3.0"

--- a/test/lib/models/candle.js
+++ b/test/lib/models/candle.js
@@ -27,7 +27,12 @@ describe('Candle model', () => {
 
   it('unserializes live data correctly', async () => {
     const rest = new RESTv2()
-    const arr = await rest.candles('tBTCUSD')
+
+    const arr = await rest.candles({
+      timeframe: '1D',
+      symbol: 'tBTCUSD',
+      section: 'hist'
+    })
 
     arr.forEach(candle => {
       const obj = Candle.unserialize(candle)

--- a/test/lib/models/funding_ticker.js
+++ b/test/lib/models/funding_ticker.js
@@ -101,7 +101,7 @@ describe('FundingTicker model', () => {
 
   it('unserializes live data correctly', async () => {
     const rest = new RESTv2()
-    const arr = await rest.ticker('fUSD')
+    const arr = await rest.ticker({ symbol: 'fUSD' })
     const obj = FundingTicker.unserialize(arr)
 
     assert.strictEqual(obj.symbol, arr[0])

--- a/test/lib/models/funding_ticker_hist.js
+++ b/test/lib/models/funding_ticker_hist.js
@@ -74,7 +74,7 @@ describe('FundingTicker history model', () => {
 
   it('unserializes live data correctly', async () => {
     const rest = new RESTv2()
-    const arr = await rest.ticker('fUSD')
+    const arr = await rest.ticker({ symbol: 'fUSD' })
     const obj = FundingTickerHist.unserialize(arr)
 
     assert.strictEqual(obj.symbol, arr[0])

--- a/test/lib/models/order.js
+++ b/test/lib/models/order.js
@@ -512,7 +512,7 @@ describe('Order model', () => {
     it('calls cancelOrder on the interface', (done) => {
       const o = new Order({ id: 42 })
       o.cancel({
-        cancelOrder: async (id) => {
+        cancelOrder: async ({ id }) => {
           assert.strictEqual(id, 42)
           done()
           return []

--- a/test/lib/models/order_book.js
+++ b/test/lib/models/order_book.js
@@ -766,7 +766,10 @@ describe('OrderBook model', () => {
 
   it('unserializes live trading data correctly', async () => {
     const rest = new RESTv2()
-    const book = await rest.orderBook('tBTCUSD', 'P0')
+    const book = await rest.orderBook({
+      symbol: 'tBTCUSD',
+      prec: 'P0'
+    })
     const obj = new OrderBook(book)
     let firstAsk = -1
 
@@ -789,7 +792,10 @@ describe('OrderBook model', () => {
 
   it('unserializes live funding data correctly', async () => {
     const rest = new RESTv2()
-    const book = await rest.orderBook('fUSD', 'P0')
+    const book = await rest.orderBook({
+      symbol: 'fUSD',
+      prec: 'P0'
+    })
     const obj = new OrderBook(book)
     let firstAsk = -1
 

--- a/test/lib/models/position.js
+++ b/test/lib/models/position.js
@@ -83,7 +83,7 @@ describe('Position model', () => {
     it('calls claimPosition on the interface', (done) => {
       const p = new Position({ id: 42 })
       p.claim({
-        claimPosition: async (id) => {
+        claimPosition: async ({ id }) => {
           assert.strictEqual(id, 42)
           done()
           return []

--- a/test/lib/models/trading_ticker.js
+++ b/test/lib/models/trading_ticker.js
@@ -90,7 +90,7 @@ describe('TradingTicker model', () => {
 
   it('unserializes live data correctly', async () => {
     const rest = new RESTv2()
-    const arr = await rest.ticker('tBTCUSD')
+    const arr = await rest.ticker({ symbol: 'tBTCUSD' })
     const obj = TradingTicker.unserialize(arr)
 
     assert.strictEqual(obj.symbol, arr[0])

--- a/test/lib/models/trading_ticker_hist.js
+++ b/test/lib/models/trading_ticker_hist.js
@@ -71,7 +71,7 @@ describe('TradingTickerHistory model', () => {
 
   it('unserializes live data correctly', async () => {
     const rest = new RESTv2()
-    const arr = await rest.ticker('tBTCUSD')
+    const arr = await rest.ticker({ symbol: 'tBTCUSD' })
     const obj = TradingTickerHist.unserialize(arr)
 
     assert.strictEqual(obj.symbol, arr[0])


### PR DESCRIPTION
### Description:

This PR changes `FundingOffer`, `Order`, `Position` model to support new rest api signature

### Fixes:
- [x] changes FundingOffer, Order, Position model to support new rest api signature
- [x] fixes test coverage to support new rest api signature

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Tests added or updated
- [ ] Documentation updated
